### PR TITLE
support numberic subtypes with .Number assertion helper

### DIFF
--- a/number.go
+++ b/number.go
@@ -3,9 +3,9 @@ package gunit
 import "math"
 
 type Numeric interface {
-	int | int8 | int16 | int32 | int64 |
-		uint | uint8 | uint16 | uint32 | uint64 |
-		float32 | float64
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
+		~float32 | ~float64
 }
 
 func Number[N Numeric](t T, actual N) *Num[N] {

--- a/number_test.go
+++ b/number_test.go
@@ -5,6 +5,35 @@ import (
 	"testing"
 )
 
+func TestNumber_subtypes(t *testing.T) {
+	type (
+		MyInt     int
+		MyInt8    int8
+		MyInt16   int16
+		MyInt32   int32
+		MyInt64   int64
+		MyUint    uint
+		MyUint8   uint8
+		MyUint16  uint16
+		MyUint32  uint32
+		MyUint64  uint64
+		MyFloat32 float32
+		MyFloat64 float64
+	)
+	Number(t, MyInt(42)).EqualTo(42)
+	Number(t, MyInt8(42)).EqualTo(42)
+	Number(t, MyInt16(42)).EqualTo(42)
+	Number(t, MyInt32(42)).EqualTo(42)
+	Number(t, MyInt64(42)).EqualTo(42)
+	Number(t, MyUint(42)).EqualTo(42)
+	Number(t, MyUint8(42)).EqualTo(42)
+	Number(t, MyUint16(42)).EqualTo(42)
+	Number(t, MyUint32(42)).EqualTo(42)
+	Number(t, MyUint64(42)).EqualTo(42)
+	Number(t, MyFloat32(42)).EqualTo(42)
+	Number(t, MyFloat64(42)).EqualTo(42)
+}
+
 func Test_int32_EqualTo(t *testing.T) {
 	Number(t, int32(11)).EqualTo(11)
 }


### PR DESCRIPTION
Hello, fellow assertion helper pkg developer,

Allow me to contribute to your fantastic project.
I would like to add support for user-defined numeric subtypes.

```go
gunit.Number(t, MyInt(42)).EqualTo(42)
```

Best of luck on your journey!

Cheers,
Adam