### PR TITLE
Add hammy reader assertions

### DIFF
--- a/hammy/reader.go
+++ b/hammy/reader.go
@@ -1,0 +1,82 @@
+package hammy
+
+import (
+	"bytes"
+	"io"
+	"strings"
+)
+
+// Reader creates assertions for an io.Reader.
+//
+// Assertions read and buffer the reader body on first use. Reading consumes the
+// supplied reader unless the reader's implementation handles buffering or
+// resetting itself; repeated assertions on the same ReaderAssert reuse the
+// buffered bytes.
+func Reader(actual io.Reader) *ReaderAssert {
+	return &ReaderAssert{actual: actual}
+}
+
+type ReaderAssert struct {
+	actual io.Reader
+	body   []byte
+	read   bool
+}
+
+func (r *ReaderAssert) EqualToString(expected string) AssertionMessage {
+	actual, result := r.readAll()
+	if !result.IsSuccessful {
+		return result
+	}
+	actualString := string(actual)
+	return Assert(actualString == expected, "got reader string <%s>, wanted <%s>", actualString, expected)
+}
+
+func (r *ReaderAssert) ContainsString(expected string) AssertionMessage {
+	actual, result := r.readAll()
+	if !result.IsSuccessful {
+		return result
+	}
+	actualString := string(actual)
+	return Assert(strings.Contains(actualString, expected), "got reader string <%s>, wanted substring <%s>", actualString, expected)
+}
+
+func (r *ReaderAssert) EqualToBytes(expected []byte) AssertionMessage {
+	actual, result := r.readAll()
+	if !result.IsSuccessful {
+		return result
+	}
+	return Assert(bytes.Equal(actual, expected), "got reader bytes <%v>, wanted <%v>", actual, expected)
+}
+
+func (r *ReaderAssert) IsEmpty() AssertionMessage {
+	actual, result := r.readAll()
+	if !result.IsSuccessful {
+		return result
+	}
+	return Assert(len(actual) == 0, "got reader len()=%d, wanted empty reader", len(actual))
+}
+
+func (r *ReaderAssert) NotEmpty() AssertionMessage {
+	actual, result := r.readAll()
+	if !result.IsSuccessful {
+		return result
+	}
+	return Assert(len(actual) != 0, "got empty reader, wanted non-empty reader")
+}
+
+func (r *ReaderAssert) readAll() ([]byte, AssertionMessage) {
+	if r.actual == nil {
+		return nil, Assert(false, "got nil reader, wanted reader body")
+	}
+	if r.read {
+		return r.body, Assert(true, "read reader")
+	}
+
+	body, err := io.ReadAll(r.actual)
+	if err != nil {
+		return nil, Assert(false, "got reader read error: %v", err)
+	}
+	r.body = body
+	r.read = true
+	return body, Assert(true, "read reader")
+}

--- a/hammy/reader_test.go
+++ b/hammy/reader_test.go
@@ -1,0 +1,95 @@
+package hammy_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gogunit/gunit/eye"
+	a "github.com/gogunit/gunit/hammy"
+)
+
+func Test_reader_EqualToString_success(t *testing.T) {
+	a.New(t).Is(a.Reader(strings.NewReader("hello world")).EqualToString("hello world"))
+}
+
+func Test_reader_EqualToString_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	a.New(aSpy).Is(a.Reader(strings.NewReader("hello world")).EqualToString("goodbye"))
+	aSpy.HadErrorContaining(t, "got reader string <hello world>, wanted <goodbye>")
+}
+
+func Test_reader_ContainsString_success(t *testing.T) {
+	a.New(t).Is(a.Reader(strings.NewReader("hello world")).ContainsString("world"))
+}
+
+func Test_reader_ContainsString_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	a.New(aSpy).Is(a.Reader(strings.NewReader("hello world")).ContainsString("goodbye"))
+	aSpy.HadErrorContaining(t, "got reader string <hello world>, wanted substring <goodbye>")
+}
+
+func Test_reader_EqualToBytes_success(t *testing.T) {
+	a.New(t).Is(a.Reader(strings.NewReader("abc")).EqualToBytes([]byte("abc")))
+}
+
+func Test_reader_EqualToBytes_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	a.New(aSpy).Is(a.Reader(strings.NewReader("abc")).EqualToBytes([]byte("cba")))
+	aSpy.HadErrorContaining(t, "got reader bytes <[97 98 99]>, wanted <[99 98 97]>")
+}
+
+func Test_reader_IsEmpty_success(t *testing.T) {
+	a.New(t).Is(a.Reader(strings.NewReader("")).IsEmpty())
+}
+
+func Test_reader_IsEmpty_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	a.New(aSpy).Is(a.Reader(strings.NewReader("hello")).IsEmpty())
+	aSpy.HadErrorContaining(t, "got reader len()=5, wanted empty reader")
+}
+
+func Test_reader_NotEmpty_success(t *testing.T) {
+	a.New(t).Is(a.Reader(strings.NewReader("hello")).NotEmpty())
+}
+
+func Test_reader_NotEmpty_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	a.New(aSpy).Is(a.Reader(strings.NewReader("")).NotEmpty())
+	aSpy.HadErrorContaining(t, "got empty reader, wanted non-empty reader")
+}
+
+func Test_reader_nil_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	a.New(aSpy).Is(a.Reader(nil).EqualToString("hello"))
+	aSpy.HadErrorContaining(t, "got nil reader, wanted reader body")
+}
+
+func Test_reader_read_error_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	a.New(aSpy).Is(a.Reader(errorReader{}).EqualToString("hello"))
+	aSpy.HadErrorContaining(t, "got reader read error: boom")
+}
+
+func Test_reader_reuses_buffered_body_after_first_read(t *testing.T) {
+	reader := strings.NewReader("hello")
+	assert := a.Reader(reader)
+
+	a.New(t).Is(assert.EqualToString("hello"))
+	a.New(t).Is(assert.ContainsString("ell"))
+
+	remaining, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("got remaining reader bytes <%v>, wanted empty reader after assertion", remaining)
+	}
+}
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errors.New("boom")
+}


### PR DESCRIPTION
### Motivation

- Add reader-focused assertions to Hammy so tests can assert `io.Reader` contents (string/bytes) and emptiness using the same style as existing buffer assertions. 
- Ensure assertions are practical for real readers by documenting and handling the fact that reading consumes the supplied `io.Reader` and by reusing a buffered copy for repeated assertions.

### Description

- Add `Reader(actual io.Reader) *ReaderAssert` and a `ReaderAssert` type in `hammy/reader.go` with methods `EqualToString`, `ContainsString`, `EqualToBytes`, `IsEmpty`, and `NotEmpty` implemented to return `AssertionMessage` results. 
- Implement a `readAll` helper that reads and caches the reader body on first use, returns clear failure messages for nil readers and read errors, and reuses the cached body for subsequent assertions. 
- Document the reader-consumption behavior in the file-level comment so callers know that the supplied reader is consumed unless it implements its own buffering/reset. 
- Add `hammy/reader_test.go` with tests covering success and failure cases for each assertion, nil-reader and read-error handling, and verification that the buffered body is reused after the first read.

### Testing

- Ran `go test ./...` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ee0759f0832d8f52f47e0efc2695)