### PR TITLE
Add root time assertions

### DIFF
--- a/time.go
+++ b/time.go
@@ -1,0 +1,65 @@
+package gunit
+
+import "time"
+
+func Time(t T, actual time.Time) *Tim {
+	return &Tim{t: t, actual: actual}
+}
+
+type Tim struct {
+	t      T
+	actual time.Time
+}
+
+func (t *Tim) EqualTo(expected time.Time) {
+	t.t.Helper()
+	if !t.actual.Equal(expected) {
+		t.t.Errorf("got <%v>, wanted equal to <%v>", t.actual, expected)
+	}
+}
+
+func (t *Tim) Before(expected time.Time) {
+	t.t.Helper()
+	if !t.actual.Before(expected) {
+		t.t.Errorf("got <%v>, wanted before <%v>", t.actual, expected)
+	}
+}
+
+func (t *Tim) BeforeOrEqual(expected time.Time) {
+	t.t.Helper()
+	if !t.actual.Before(expected) && !t.actual.Equal(expected) {
+		t.t.Errorf("got <%v>, wanted before or equal to <%v>", t.actual, expected)
+	}
+}
+
+func (t *Tim) After(expected time.Time) {
+	t.t.Helper()
+	if !t.actual.After(expected) {
+		t.t.Errorf("got <%v>, wanted after <%v>", t.actual, expected)
+	}
+}
+
+func (t *Tim) AfterOrEqual(expected time.Time) {
+	t.t.Helper()
+	if !t.actual.After(expected) && !t.actual.Equal(expected) {
+		t.t.Errorf("got <%v>, wanted after or equal to <%v>", t.actual, expected)
+	}
+}
+
+func (t *Tim) WithinDuration(expected time.Time, delta time.Duration) {
+	t.t.Helper()
+	diff := t.actual.Sub(expected)
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > delta {
+		t.t.Errorf("got <%v>, wanted within <%v> of <%v>", t.actual, delta, expected)
+	}
+}
+
+func (t *Tim) WithinRange(start, end time.Time) {
+	t.t.Helper()
+	if (t.actual.Before(start) && !t.actual.Equal(start)) || (t.actual.After(end) && !t.actual.Equal(end)) {
+		t.t.Errorf("got <%v>, wanted in range <%v> to <%v>", t.actual, start, end)
+	}
+}

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,119 @@
+package gunit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gogunit/gunit"
+	"github.com/gogunit/gunit/eye"
+)
+
+func Test_Time_EqualTo_success(t *testing.T) {
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(t, actual).EqualTo(actual)
+}
+
+func Test_Time_EqualTo_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(aSpy, actual).EqualTo(actual.Add(time.Second))
+
+	aSpy.HadErrorContaining(t, "wanted equal to")
+}
+
+func Test_Time_Before_success(t *testing.T) {
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(t, actual).Before(actual.Add(time.Second))
+}
+
+func Test_Time_Before_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(aSpy, actual).Before(actual)
+
+	aSpy.HadErrorContaining(t, "wanted before")
+}
+
+func Test_Time_BeforeOrEqual_success(t *testing.T) {
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(t, actual).BeforeOrEqual(actual)
+	gunit.Time(t, actual.Add(-time.Second)).BeforeOrEqual(actual)
+}
+
+func Test_Time_BeforeOrEqual_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(aSpy, actual.Add(time.Second)).BeforeOrEqual(actual)
+
+	aSpy.HadErrorContaining(t, "wanted before or equal")
+}
+
+func Test_Time_After_success(t *testing.T) {
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(t, actual).After(actual.Add(-time.Second))
+}
+
+func Test_Time_After_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(aSpy, actual).After(actual)
+
+	aSpy.HadErrorContaining(t, "wanted after")
+}
+
+func Test_Time_AfterOrEqual_success(t *testing.T) {
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(t, actual).AfterOrEqual(actual)
+	gunit.Time(t, actual.Add(time.Second)).AfterOrEqual(actual)
+}
+
+func Test_Time_AfterOrEqual_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	actual := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(aSpy, actual.Add(-time.Second)).AfterOrEqual(actual)
+
+	aSpy.HadErrorContaining(t, "wanted after or equal")
+}
+
+func Test_Time_WithinDuration_success(t *testing.T) {
+	expected := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(t, expected.Add(500*time.Millisecond)).WithinDuration(expected, time.Second)
+}
+
+func Test_Time_WithinDuration_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	expected := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+
+	gunit.Time(aSpy, expected.Add(2*time.Second)).WithinDuration(expected, time.Second)
+
+	aSpy.HadErrorContaining(t, "wanted within <1s>")
+}
+
+func Test_Time_WithinRange_success_inclusive(t *testing.T) {
+	start := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	gunit.Time(t, start).WithinRange(start, end)
+	gunit.Time(t, end).WithinRange(start, end)
+}
+
+func Test_Time_WithinRange_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	start := time.Date(2026, 5, 12, 10, 30, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	gunit.Time(aSpy, start.Add(-time.Second)).WithinRange(start, end)
+
+	aSpy.HadErrorContaining(t, "wanted in range")
+}


### PR DESCRIPTION
### Motivation
- Provide root-package `time.Time` assertion helpers mirroring the existing `hammy` matchers so tests can use concise time assertions directly from `gunit`. 
- Support common time checks including equality, ordering, delta tolerance, and inclusive ranges for clearer test code.

### Description
- Add `time.go` with `func Time(t T, actual time.Time) *Tim` and `type Tim struct { t T; actual time.Time }` providing assertion methods. 
- Implement `EqualTo`, `Before`, `BeforeOrEqual`, `After`, `AfterOrEqual`, `WithinDuration(expected time.Time, delta time.Duration)`, and `WithinRange(start, end time.Time)` in `time.go`. 
- Add `time_test.go` with unit tests mirroring `hammy/time_test.go` to cover success and failure cases for each new assertion.

### Testing
- Ran `go test ./...` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ee208d50832db8565fc7bfe56968)