### PR TITLE
Add URL assertion helpers and unit tests to hammy

### DIFF
--- a/hammy/url.go
+++ b/hammy/url.go
@@ -1,0 +1,93 @@
+package hammy
+
+import "net/url"
+
+func URL(actual *url.URL) *URLAssert {
+	if actual == nil {
+		return &URLAssert{validation: invalidURL("got nil URL")}
+	}
+	return &URLAssert{actual: actual}
+}
+
+func ParseURL(actual string) *URLAssert {
+	parsed, err := url.Parse(actual)
+	if err != nil {
+		return &URLAssert{validation: invalidURL("invalid URL <%s>: %v", actual, err)}
+	}
+	return URL(parsed)
+}
+
+type URLAssert struct {
+	actual     *url.URL
+	validation *AssertionMessage
+}
+
+func (u *URLAssert) Scheme(expected string) AssertionMessage {
+	if msg := u.ready(); !msg.IsSuccessful {
+		return msg
+	}
+	return Assert(u.actual.Scheme == expected, "got URL scheme <%s>, wanted <%s>", u.actual.Scheme, expected)
+}
+
+func (u *URLAssert) Host(expected string) AssertionMessage {
+	if msg := u.ready(); !msg.IsSuccessful {
+		return msg
+	}
+	return Assert(u.actual.Host == expected, "got URL host <%s>, wanted <%s>", u.actual.Host, expected)
+}
+
+func (u *URLAssert) Path(expected string) AssertionMessage {
+	if msg := u.ready(); !msg.IsSuccessful {
+		return msg
+	}
+	return Assert(u.actual.Path == expected, "got URL path <%s>, wanted <%s>", u.actual.Path, expected)
+}
+
+func (u *URLAssert) RawQuery(expected string) AssertionMessage {
+	if msg := u.ready(); !msg.IsSuccessful {
+		return msg
+	}
+	return Assert(u.actual.RawQuery == expected, "got URL raw query <%s>, wanted <%s>", u.actual.RawQuery, expected)
+}
+
+func (u *URLAssert) QueryParam(key, expected string) AssertionMessage {
+	if msg := u.ready(); !msg.IsSuccessful {
+		return msg
+	}
+
+	values, ok := u.actual.Query()[key]
+	if !ok {
+		return Assert(false, "missing URL query parameter <%s>, wanted <%s>", key, expected)
+	}
+
+	actual := values[0]
+	return Assert(actual == expected, "got URL query parameter <%s> value <%s>, wanted <%s>", key, actual, expected)
+}
+
+func (u *URLAssert) NoQueryParam(key string) AssertionMessage {
+	if msg := u.ready(); !msg.IsSuccessful {
+		return msg
+	}
+
+	_, ok := u.actual.Query()[key]
+	return Assert(!ok, "got URL query parameter <%s>, wanted it absent", key)
+}
+
+func (u *URLAssert) String(expected string) AssertionMessage {
+	if msg := u.ready(); !msg.IsSuccessful {
+		return msg
+	}
+	return Assert(u.actual.String() == expected, "got URL string <%s>, wanted <%s>", u.actual.String(), expected)
+}
+
+func invalidURL(str string, args ...any) *AssertionMessage {
+	msg := Assert(false, str, args...)
+	return &msg
+}
+
+func (u *URLAssert) ready() AssertionMessage {
+	if u.validation != nil {
+		return *u.validation
+	}
+	return Assert(true, "")
+}

--- a/hammy/url_test.go
+++ b/hammy/url_test.go
@@ -1,0 +1,156 @@
+package hammy_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/gogunit/gunit/eye"
+	a "github.com/gogunit/gunit/hammy"
+)
+
+func Test_URL_Scheme_success(t *testing.T) {
+	assert := a.New(t)
+	actual, err := url.Parse("https://example.com/path?name=hammy&empty=")
+	assert.Is(a.NilError(err))
+
+	assert.Is(a.URL(actual).Scheme("https"))
+}
+
+func Test_URL_Host_success(t *testing.T) {
+	assert := a.New(t)
+	actual, err := url.Parse("https://example.com/path?name=hammy&empty=")
+	assert.Is(a.NilError(err))
+
+	assert.Is(a.URL(actual).Host("example.com"))
+}
+
+func Test_URL_Path_success(t *testing.T) {
+	assert := a.New(t)
+	actual, err := url.Parse("https://example.com/path?name=hammy&empty=")
+	assert.Is(a.NilError(err))
+
+	assert.Is(a.URL(actual).Path("/path"))
+}
+
+func Test_URL_RawQuery_success(t *testing.T) {
+	assert := a.New(t)
+	actual, err := url.Parse("https://example.com/path?name=hammy&empty=")
+	assert.Is(a.NilError(err))
+
+	assert.Is(a.URL(actual).RawQuery("name=hammy&empty="))
+}
+
+func Test_URL_QueryParam_success(t *testing.T) {
+	assert := a.New(t)
+	actual, err := url.Parse("https://example.com/path?name=hammy&empty=")
+	assert.Is(a.NilError(err))
+
+	assert.Is(a.URL(actual).QueryParam("name", "hammy"))
+}
+
+func Test_URL_QueryParam_empty_success(t *testing.T) {
+	assert := a.New(t)
+	actual, err := url.Parse("https://example.com/path?name=hammy&empty=")
+	assert.Is(a.NilError(err))
+
+	assert.Is(a.URL(actual).QueryParam("empty", ""))
+}
+
+func Test_URL_NoQueryParam_success(t *testing.T) {
+	assert := a.New(t)
+	actual, err := url.Parse("https://example.com/path?name=hammy&empty=")
+	assert.Is(a.NilError(err))
+
+	assert.Is(a.URL(actual).NoQueryParam("missing"))
+}
+
+func Test_URL_String_success(t *testing.T) {
+	assert := a.New(t)
+	actual, err := url.Parse("https://example.com/path?name=hammy&empty=")
+	assert.Is(a.NilError(err))
+
+	assert.Is(a.URL(actual).String("https://example.com/path?name=hammy&empty="))
+}
+
+func Test_ParseURL_success(t *testing.T) {
+	assert := a.New(t)
+	assert.Is(a.ParseURL("https://example.com/path?name=hammy").Host("example.com"))
+}
+
+func Test_URL_nil_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	assert.Is(a.URL(nil).Scheme("https"))
+	aSpy.HadErrorContaining(t, "got nil URL")
+}
+
+func Test_ParseURL_invalid_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	assert.Is(a.ParseURL("http://[::1").Host("example.com"))
+	aSpy.HadErrorContaining(t, "invalid URL <http://[::1>")
+}
+
+func Test_URL_Scheme_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	actual, _ := url.Parse("http://example.com")
+	assert.Is(a.URL(actual).Scheme("https"))
+	aSpy.HadErrorContaining(t, "got URL scheme <http>, wanted <https>")
+}
+
+func Test_URL_Host_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	actual, _ := url.Parse("https://example.com")
+	assert.Is(a.URL(actual).Host("example.org"))
+	aSpy.HadErrorContaining(t, "got URL host <example.com>, wanted <example.org>")
+}
+
+func Test_URL_Path_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	actual, _ := url.Parse("https://example.com/path")
+	assert.Is(a.URL(actual).Path("/other"))
+	aSpy.HadErrorContaining(t, "got URL path </path>, wanted </other>")
+}
+
+func Test_URL_RawQuery_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	actual, _ := url.Parse("https://example.com/path?a=1")
+	assert.Is(a.URL(actual).RawQuery("a=2"))
+	aSpy.HadErrorContaining(t, "got URL raw query <a=1>, wanted <a=2>")
+}
+
+func Test_URL_QueryParam_missing_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	actual, _ := url.Parse("https://example.com/path?a=1")
+	assert.Is(a.URL(actual).QueryParam("b", "2"))
+	aSpy.HadErrorContaining(t, "missing URL query parameter <b>, wanted <2>")
+}
+
+func Test_URL_QueryParam_value_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	actual, _ := url.Parse("https://example.com/path?a=1")
+	assert.Is(a.URL(actual).QueryParam("a", "2"))
+	aSpy.HadErrorContaining(t, "got URL query parameter <a> value <1>, wanted <2>")
+}
+
+func Test_URL_NoQueryParam_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	actual, _ := url.Parse("https://example.com/path?a=1")
+	assert.Is(a.URL(actual).NoQueryParam("a"))
+	aSpy.HadErrorContaining(t, "got URL query parameter <a>, wanted it absent")
+}
+
+func Test_URL_String_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := a.New(aSpy)
+	actual, _ := url.Parse("https://example.com/path")
+	assert.Is(a.URL(actual).String("https://example.org/path"))
+	aSpy.HadErrorContaining(t, "got URL string <https://example.com/path>, wanted <https://example.org/path>")
+}


### PR DESCRIPTION
### Motivation

- Provide first-class URL assertions to the `hammy` assertion library so tests can validate URL components directly.
- Allow creating assertions from both `*url.URL` and raw string inputs with clear validation errors for invalid or nil URLs.
- Improve failure diagnostics by returning descriptive messages for scheme, host, path, query, and full-string mismatches.

### Description

- Added `hammy/url.go` which implements `URL`, `ParseURL`, and the `URLAssert` type with methods `Scheme`, `Host`, `Path`, `RawQuery`, `QueryParam`, `NoQueryParam`, and `String` using the standard `net/url` package.
- Implemented validation helpers `invalidURL` and `ready` and integrated with existing `AssertionMessage`/`Assert` flow to produce consistent error messages.
- Added comprehensive unit tests in `hammy/url_test.go` covering success and failure cases, including nil and invalid URL handling and query parameter edge cases.

### Testing

- Added unit tests in `hammy/url_test.go` that exercise all assertion methods and negative paths using `eye.Spy` for failure inspection.
- Ran the package tests with `go test ./...` which executed the new URL tests along with existing tests.
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ede1eb08832db76e7a5af7383ee8)