### PR TITLE
Add HTTP request assertion helpers and unit tests

### DIFF
--- a/hammy/httpassert/request.go
+++ b/hammy/httpassert/request.go
@@ -1,0 +1,118 @@
+package httpassert
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gogunit/gunit/hammy"
+)
+
+func Request(req *http.Request) *Req {
+	return &Req{actual: req}
+}
+
+type Req struct {
+	actual *http.Request
+}
+
+func (r *Req) Method(expected string) hammy.AssertionMessage {
+	if r == nil || r.actual == nil {
+		return hammy.Assert(false, "got nil request, wanted method <%s>", expected)
+	}
+	return hammy.Assert(r.actual.Method == expected, "got method <%s>, wanted <%s>", r.actual.Method, expected)
+}
+
+func (r *Req) Path(expected string) hammy.AssertionMessage {
+	if r == nil || r.actual == nil {
+		return hammy.Assert(false, "got nil request, wanted path <%s>", expected)
+	}
+	if r.actual.URL == nil {
+		return hammy.Assert(false, "got nil request URL, wanted path <%s>", expected)
+	}
+	return hammy.Assert(r.actual.URL.Path == expected, "got path <%s>, wanted <%s>", r.actual.URL.Path, expected)
+}
+
+func (r *Req) URL(expected string) hammy.AssertionMessage {
+	if r == nil || r.actual == nil {
+		return hammy.Assert(false, "got nil request, wanted URL <%s>", expected)
+	}
+	if r.actual.URL == nil {
+		return hammy.Assert(false, "got nil request URL, wanted URL <%s>", expected)
+	}
+	actual := r.actual.URL.String()
+	return hammy.Assert(actual == expected, "got URL <%s>, wanted <%s>", actual, expected)
+}
+
+func (r *Req) URLEqual(expected string) hammy.AssertionMessage {
+	return r.URL(expected)
+}
+
+func (r *Req) Host(expected string) hammy.AssertionMessage {
+	if r == nil || r.actual == nil {
+		return hammy.Assert(false, "got nil request, wanted host <%s>", expected)
+	}
+	return hammy.Assert(r.actual.Host == expected, "got host <%s>, wanted <%s>", r.actual.Host, expected)
+}
+
+func (r *Req) Header(key, expected string) hammy.AssertionMessage {
+	if r == nil || r.actual == nil {
+		return hammy.Assert(false, "got nil request, wanted header <%s> equal to <%s>", key, expected)
+	}
+	actual := r.actual.Header.Get(key)
+	return hammy.Assert(actual == expected, "got header <%s>=<%s>, wanted <%s>", key, actual, expected)
+}
+
+func (r *Req) HeaderContains(key, expected string) hammy.AssertionMessage {
+	if r == nil || r.actual == nil {
+		return hammy.Assert(false, "got nil request, wanted header <%s> containing <%s>", key, expected)
+	}
+	actual := r.actual.Header.Get(key)
+	return hammy.Assert(strings.Contains(actual, expected), "got header <%s>=<%s>, wanted containing <%s>", key, actual, expected)
+}
+
+func (r *Req) QueryParam(key, expected string) hammy.AssertionMessage {
+	if r == nil || r.actual == nil {
+		return hammy.Assert(false, "got nil request, wanted query param <%s> equal to <%s>", key, expected)
+	}
+	if r.actual.URL == nil {
+		return hammy.Assert(false, "got nil request URL, wanted query param <%s> equal to <%s>", key, expected)
+	}
+	actual := r.actual.URL.Query().Get(key)
+	return hammy.Assert(actual == expected, "got query param <%s>=<%s>, wanted <%s>", key, actual, expected)
+}
+
+func (r *Req) BodyEqual(expected string) hammy.AssertionMessage {
+	actual, result := readRequestBody(r)
+	if !result.IsSuccessful {
+		return result
+	}
+	return hammy.Assert(actual == expected, "got body <%s>, wanted equal to <%s>", actual, expected)
+}
+
+func (r *Req) BodyContains(expected string) hammy.AssertionMessage {
+	actual, result := readRequestBody(r)
+	if !result.IsSuccessful {
+		return result
+	}
+	return hammy.Assert(strings.Contains(actual, expected), "got body <%s>, wanted containing <%s>", actual, expected)
+}
+
+func readRequestBody(r *Req) (string, hammy.AssertionMessage) {
+	if r == nil || r.actual == nil {
+		return "", hammy.Assert(false, "got nil request, wanted request body")
+	}
+	if r.actual.Body == nil {
+		r.actual.Body = io.NopCloser(bytes.NewReader(nil))
+		return "", hammy.Assert(true, "read body")
+	}
+
+	body, err := io.ReadAll(r.actual.Body)
+	_ = r.actual.Body.Close()
+	r.actual.Body = io.NopCloser(bytes.NewReader(body))
+	if err != nil {
+		return "", hammy.Assert(false, "got body read error: %v", err)
+	}
+	return string(body), hammy.Assert(true, "read body")
+}

--- a/hammy/httpassert/request_test.go
+++ b/hammy/httpassert/request_test.go
@@ -1,0 +1,247 @@
+package httpassert_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gogunit/gunit/eye"
+	"github.com/gogunit/gunit/hammy"
+	"github.com/gogunit/gunit/hammy/httpassert"
+)
+
+func Test_Request_Method_success(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodPost, "https://example.com/widgets", "")
+
+	assert.Is(httpassert.Request(req).Method(http.MethodPost))
+}
+
+func Test_Request_Method_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodPost, "https://example.com/widgets", "")
+
+	assert.Is(httpassert.Request(req).Method(http.MethodGet))
+
+	aSpy.HadErrorContaining(t, "got method <POST>, wanted <GET>")
+}
+
+func Test_Request_Method_failure_nil_request(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+
+	assert.Is(httpassert.Request(nil).Method(http.MethodGet))
+
+	aSpy.HadErrorContaining(t, "got nil request")
+}
+
+func Test_Request_Path_success(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodGet, "https://example.com/widgets/1?expand=true", "")
+
+	assert.Is(httpassert.Request(req).Path("/widgets/1"))
+}
+
+func Test_Request_Path_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodGet, "https://example.com/widgets/1", "")
+
+	assert.Is(httpassert.Request(req).Path("/widgets/2"))
+
+	aSpy.HadErrorContaining(t, "got path </widgets/1>, wanted </widgets/2>")
+}
+
+func Test_Request_URL_success(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodGet, "https://example.com/widgets/1?expand=true", "")
+
+	assert.Is(httpassert.Request(req).URL("https://example.com/widgets/1?expand=true"))
+	assert.Is(httpassert.Request(req).URLEqual("https://example.com/widgets/1?expand=true"))
+}
+
+func Test_Request_URL_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodGet, "https://example.com/widgets/1", "")
+
+	assert.Is(httpassert.Request(req).URL("https://example.com/widgets/2"))
+
+	aSpy.HadErrorContaining(t, "got URL <https://example.com/widgets/1>, wanted <https://example.com/widgets/2>")
+}
+
+func Test_Request_URL_failure_nil_URL(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+
+	assert.Is(httpassert.Request(&http.Request{}).URL("https://example.com"))
+
+	aSpy.HadErrorContaining(t, "got nil request URL")
+}
+
+func Test_Request_Host_success(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodGet, "https://example.com/widgets", "")
+
+	assert.Is(httpassert.Request(req).Host("example.com"))
+}
+
+func Test_Request_Host_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodGet, "https://example.com/widgets", "")
+
+	assert.Is(httpassert.Request(req).Host("api.example.com"))
+
+	aSpy.HadErrorContaining(t, "got host <example.com>, wanted <api.example.com>")
+}
+
+func Test_Request_Header_success(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodGet, "https://example.com/widgets", "")
+	req.Header.Set("Accept", "application/json")
+
+	assert.Is(httpassert.Request(req).Header("Accept", "application/json"))
+}
+
+func Test_Request_Header_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodGet, "https://example.com/widgets", "")
+	req.Header.Set("Accept", "text/plain")
+
+	assert.Is(httpassert.Request(req).Header("Accept", "application/json"))
+
+	aSpy.HadErrorContaining(t, "got header <Accept>=<text/plain>, wanted <application/json>")
+}
+
+func Test_Request_HeaderContains_success(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodGet, "https://example.com/widgets", "")
+	req.Header.Set("Accept", "application/json; charset=utf-8")
+
+	assert.Is(httpassert.Request(req).HeaderContains("Accept", "application/json"))
+}
+
+func Test_Request_HeaderContains_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodGet, "https://example.com/widgets", "")
+	req.Header.Set("Accept", "text/plain")
+
+	assert.Is(httpassert.Request(req).HeaderContains("Accept", "application/json"))
+
+	aSpy.HadErrorContaining(t, "got header <Accept>=<text/plain>, wanted containing <application/json>")
+}
+
+func Test_Request_QueryParam_success(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodGet, "https://example.com/widgets?expand=true", "")
+
+	assert.Is(httpassert.Request(req).QueryParam("expand", "true"))
+}
+
+func Test_Request_QueryParam_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodGet, "https://example.com/widgets?expand=false", "")
+
+	assert.Is(httpassert.Request(req).QueryParam("expand", "true"))
+
+	aSpy.HadErrorContaining(t, "got query param <expand>=<false>, wanted <true>")
+}
+
+func Test_Request_BodyEqual_success(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodPost, "https://example.com/widgets", "hello world")
+
+	assert.Is(httpassert.Request(req).BodyEqual("hello world"))
+}
+
+func Test_Request_BodyEqual_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodPost, "https://example.com/widgets", "hello world")
+
+	assert.Is(httpassert.Request(req).BodyEqual("goodbye"))
+
+	aSpy.HadErrorContaining(t, "got body <hello world>, wanted equal to <goodbye>")
+}
+
+func Test_Request_BodyContains_success(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodPost, "https://example.com/widgets", "hello world")
+
+	assert.Is(httpassert.Request(req).BodyContains("world"))
+}
+
+func Test_Request_BodyContains_failure(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodPost, "https://example.com/widgets", "hello world")
+
+	assert.Is(httpassert.Request(req).BodyContains("goodbye"))
+
+	aSpy.HadErrorContaining(t, "got body <hello world>, wanted containing <goodbye>")
+}
+
+func Test_Request_Body_assertions_restore_body(t *testing.T) {
+	assert := hammy.New(t)
+	req := newRequest(http.MethodPost, "https://example.com/widgets", "hello world")
+
+	assert.Is(httpassert.Request(req).BodyContains("hello"))
+	assert.Is(httpassert.Request(req).BodyEqual("hello world"))
+}
+
+func Test_Request_Body_assertion_failure_nil_request(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+
+	assert.Is(httpassert.Request(nil).BodyEqual("hello"))
+
+	aSpy.HadErrorContaining(t, "got nil request")
+}
+
+func Test_Request_Body_assertion_failure_read_error(t *testing.T) {
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	req := newRequest(http.MethodPost, "https://example.com/widgets", "")
+	req.Body = requestErrorReadCloser{}
+
+	assert.Is(httpassert.Request(req).BodyEqual("hello"))
+
+	aSpy.HadErrorContaining(t, "got body read error: read failed")
+}
+
+func newRequest(method, rawURL, body string) *http.Request {
+	req := &http.Request{
+		Method: method,
+		Header: make(http.Header),
+		Body:   io.NopCloser(strings.NewReader(body)),
+	}
+	req.URL = mustParseURL(rawURL)
+	req.Host = req.URL.Host
+	return req
+}
+
+func mustParseURL(rawURL string) *url.URL {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
+type requestErrorReadCloser struct{}
+
+func (requestErrorReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (requestErrorReadCloser) Close() error {
+	return nil
+}


### PR DESCRIPTION
### Motivation

- Provide a set of test helpers to assert properties of `http.Request` values for use with the `hammy` assertion framework.
- Make it easy to assert method, path, full URL, host, headers, query params and request body content in tests while safely handling nils and restoring the request body after reads.

### Description

- Add `hammy/httpassert/request.go` which exposes `Request(req *http.Request) *Req` and assertion methods `Method`, `Path`, `URL`, `URLEqual`, `Host`, `Header`, `HeaderContains`, `QueryParam`, `BodyEqual`, and `BodyContains` that return `hammy.AssertionMessage` and validate nil inputs.
- Implement `readRequestBody` to read the request body, return it as a string, handle read errors, and restore `req.Body` so assertions are non-destructive.
- Add comprehensive tests in `hammy/httpassert/request_test.go` covering success and failure scenarios for each assertion, behavior when the request or URL is nil, and error handling when reading the request body fails.
- Use the `eye.Spy` test spy to assert error messages produced by failing assertions.

### Testing

- Ran the package unit tests with `go test ./hammy/httpassert -v`, which executed the new `request_test.go` tests and completed successfully.
- Tests cover positive and negative cases for each assertion and verify that the request body is restored after assertions and that read errors are reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ee414930832d8c07c96053ff570c)