### PR TITLE
Use `eye.Spy` for assertion failure checks and remove `requireFailure` helpers

### DIFF
--- a/hammy/httpassert/httpassert_test.go
+++ b/hammy/httpassert/httpassert_test.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	"github.com/gogunit/gunit/eye"
 	"github.com/gogunit/gunit/hammy"
 	"github.com/gogunit/gunit/hammy/httpassert"
 )
@@ -22,13 +22,19 @@ func Test_Status_success(t *testing.T) {
 func Test_Status_failure(t *testing.T) {
 	result := httpassert.Status(newResponse(http.StatusCreated, nil, ""), http.StatusOK)
 
-	requireFailure(t, result, "got status <201>, wanted <200>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got status <201>, wanted <200>")
 }
 
 func Test_Status_failure_nil_response(t *testing.T) {
 	result := httpassert.Status(nil, http.StatusOK)
 
-	requireFailure(t, result, "got nil response")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got nil response")
 }
 
 func Test_StatusInRange_success(t *testing.T) {
@@ -41,13 +47,19 @@ func Test_StatusInRange_success(t *testing.T) {
 func Test_StatusInRange_failure(t *testing.T) {
 	result := httpassert.StatusInRange(newResponse(http.StatusBadRequest, nil, ""), 200, 299)
 
-	requireFailure(t, result, "got status <400>, wanted in range <200..299>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got status <400>, wanted in range <200..299>")
 }
 
 func Test_StatusInRange_failure_invalid_range(t *testing.T) {
 	result := httpassert.StatusInRange(newResponse(http.StatusOK, nil, ""), 299, 200)
 
-	requireFailure(t, result, "got invalid status range <299..200>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got invalid status range <299..200>")
 }
 
 func Test_Header_success(t *testing.T) {
@@ -61,7 +73,10 @@ func Test_Header_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, http.Header{"Content-Type": {"text/plain"}}, "")
 	result := httpassert.Header(resp, "Content-Type", "application/json")
 
-	requireFailure(t, result, "got header <Content-Type>=<text/plain>, wanted <application/json>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got header <Content-Type>=<text/plain>, wanted <application/json>")
 }
 
 func Test_HeaderContains_success(t *testing.T) {
@@ -75,7 +90,10 @@ func Test_HeaderContains_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, http.Header{"Content-Type": {"text/plain"}}, "")
 	result := httpassert.HeaderContains(resp, "Content-Type", "application/json")
 
-	requireFailure(t, result, "got header <Content-Type>=<text/plain>, wanted containing <application/json>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got header <Content-Type>=<text/plain>, wanted containing <application/json>")
 }
 
 func Test_BodyEqual_success(t *testing.T) {
@@ -89,7 +107,10 @@ func Test_BodyEqual_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "hello world")
 	result := httpassert.BodyEqual(resp, "goodbye")
 
-	requireFailure(t, result, "got body <hello world>, wanted equal to <goodbye>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got body <hello world>, wanted equal to <goodbye>")
 }
 
 func Test_BodyContains_success(t *testing.T) {
@@ -103,7 +124,10 @@ func Test_BodyContains_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "hello world")
 	result := httpassert.BodyContains(resp, "goodbye")
 
-	requireFailure(t, result, "got body <hello world>, wanted containing <goodbye>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got body <hello world>, wanted containing <goodbye>")
 }
 
 func Test_BodyMatchesRegexp_success(t *testing.T) {
@@ -117,14 +141,20 @@ func Test_BodyMatchesRegexp_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "status 204")
 	result := httpassert.BodyMatchesRegexp(resp, `status 5\d\d`)
 
-	requireFailure(t, result, "got body <status 204>, wanted regexp <status 5\\d\\d>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got body <status 204>, wanted regexp <status 5\\d\\d>")
 }
 
 func Test_BodyMatchesRegexp_failure_invalid_pattern(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "status 204")
 	result := httpassert.BodyMatchesRegexp(resp, `(`)
 
-	requireFailure(t, result, "invalid regexp <(>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "invalid regexp <(>")
 }
 
 func Test_Body_assertions_restore_body(t *testing.T) {
@@ -139,14 +169,20 @@ func Test_Body_assertions_restore_body(t *testing.T) {
 func Test_Body_assertion_failure_nil_response(t *testing.T) {
 	result := httpassert.BodyEqual(nil, "hello")
 
-	requireFailure(t, result, "got nil response")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got nil response")
 }
 
 func Test_Body_assertion_failure_read_error(t *testing.T) {
 	resp := &http.Response{Body: errorReadCloser{}}
 	result := httpassert.BodyEqual(resp, "hello")
 
-	requireFailure(t, result, "got body read error: read failed")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got body read error: read failed")
 }
 
 func newResponse(status int, headers http.Header, body string) *http.Response {
@@ -159,16 +195,6 @@ func newResponse(status int, headers http.Header, body string) *http.Response {
 	recorder.WriteHeader(status)
 	_, _ = recorder.WriteString(body)
 	return recorder.Result()
-}
-
-func requireFailure(t *testing.T, result hammy.AssertionMessage, contains string) {
-	t.Helper()
-	if result.IsSuccessful {
-		t.Fatalf("got success, wanted failure containing %q", contains)
-	}
-	if !strings.Contains(result.Message, contains) {
-		t.Fatalf("got message %q, wanted containing %q", result.Message, contains)
-	}
 }
 
 type errorReadCloser struct{}

--- a/hammy/jsonassert/jsonassert_test.go
+++ b/hammy/jsonassert/jsonassert_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gogunit/gunit/eye"
 	"github.com/gogunit/gunit/hammy"
 	"github.com/gogunit/gunit/hammy/jsonassert"
 )
@@ -28,7 +29,10 @@ func Test_Equal_success_reordered_object_keys(t *testing.T) {
 func Test_Equal_failure_array_order_mismatch(t *testing.T) {
 	result := jsonassert.Equal(`{"values":[1,2,3]}`, `{"values":[3,2,1]}`)
 
-	requireFailure(t, result, "JSON mismatch (-want +got):")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON mismatch (-want +got):")
 }
 
 func Test_Equal_success_numeric_spelling_equivalence(t *testing.T) {
@@ -49,27 +53,39 @@ func Test_Equal_success_large_numeric_spelling_equivalence(t *testing.T) {
 func Test_Equal_failure_invalid_actual_json(t *testing.T) {
 	result := jsonassert.Equal(`{"name":`, `{"name":"Ada"}`)
 
-	requireFailure(t, result, "actual JSON invalid:")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "actual JSON invalid:")
 }
 
 func Test_Equal_failure_invalid_expected_json(t *testing.T) {
 	result := jsonassert.Equal(`{"name":"Ada"}`, `{"name":`)
 
-	requireFailure(t, result, "expected JSON invalid:")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "expected JSON invalid:")
 }
 
 func Test_Equal_failure_multiple_actual_json_values(t *testing.T) {
 	result := jsonassert.Equal(`{"name":"Ada"} {"name":"Grace"}`, `{"name":"Ada"}`)
 
-	requireFailure(t, result, "actual JSON invalid: multiple JSON values")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "actual JSON invalid: multiple JSON values")
 }
 
 func Test_Equal_failure_includes_diff(t *testing.T) {
 	result := jsonassert.Equal(`{"name":"Ada"}`, `{"name":"Grace"}`)
 
-	requireFailure(t, result, "JSON mismatch (-want +got):")
-	requireFailure(t, result, `Grace`)
-	requireFailure(t, result, `Ada`)
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON mismatch (-want +got):")
+	aSpy.HadErrorContaining(t, `Grace`)
+	aSpy.HadErrorContaining(t, `Ada`)
 }
 
 func Test_EqualBytes_success(t *testing.T) {
@@ -90,13 +106,19 @@ func Test_EqualReader_success(t *testing.T) {
 func Test_EqualReader_failure_nil_actual_reader(t *testing.T) {
 	result := jsonassert.EqualReader(nil, strings.NewReader(`{"name":"Ada"}`))
 
-	requireFailure(t, result, "actual JSON reader is nil")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "actual JSON reader is nil")
 }
 
 func Test_EqualReader_failure_expected_read_error(t *testing.T) {
 	result := jsonassert.EqualReader(strings.NewReader(`{"name":"Ada"}`), errorReader{})
 
-	requireFailure(t, result, "expected JSON read error: read failed")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "expected JSON read error: read failed")
 }
 
 func Test_EqualLines_success_multiline(t *testing.T) {
@@ -177,9 +199,12 @@ func Test_EqualLines_failure_reports_line_index(t *testing.T) {
 		`{"id":1,"name":"Ada"}`+"\n"+`{"id":2,"name":"Katherine"}`,
 	)
 
-	requireFailure(t, result, "JSONL line <1> mismatch (-want +got):")
-	requireFailure(t, result, "Grace")
-	requireFailure(t, result, "Katherine")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSONL line <1> mismatch (-want +got):")
+	aSpy.HadErrorContaining(t, "Grace")
+	aSpy.HadErrorContaining(t, "Katherine")
 }
 
 func Test_EqualLinesBytes_failure_reports_line_index(t *testing.T) {
@@ -188,7 +213,10 @@ func Test_EqualLinesBytes_failure_reports_line_index(t *testing.T) {
 		[]byte(`{"id":1}`+"\n"+`{"id":3}`),
 	)
 
-	requireFailure(t, result, "JSONL line <1> mismatch (-want +got):")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSONL line <1> mismatch (-want +got):")
 }
 
 func Test_EqualLines_failure_invalid_actual_json_reports_line_index(t *testing.T) {
@@ -197,7 +225,10 @@ func Test_EqualLines_failure_invalid_actual_json_reports_line_index(t *testing.T
 		`{"id":1}`+"\n"+`{"id":2}`,
 	)
 
-	requireFailure(t, result, "actual JSONL line <1> invalid:")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "actual JSONL line <1> invalid:")
 }
 
 func Test_EqualLines_failure_invalid_expected_json_reports_line_index(t *testing.T) {
@@ -206,7 +237,10 @@ func Test_EqualLines_failure_invalid_expected_json_reports_line_index(t *testing
 		`{"id":1}`+"\n"+`{"id":`,
 	)
 
-	requireFailure(t, result, "expected JSONL line <1> invalid:")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "expected JSONL line <1> invalid:")
 }
 
 func Test_EqualLines_failure_blank_middle_line_invalid_json(t *testing.T) {
@@ -215,7 +249,10 @@ func Test_EqualLines_failure_blank_middle_line_invalid_json(t *testing.T) {
 		`{"id":1}`+"\n\n"+`{"id":2}`,
 	)
 
-	requireFailure(t, result, "actual JSONL line <1> invalid:")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "actual JSONL line <1> invalid:")
 }
 
 func Test_EqualLines_failure_line_count_mismatch_reports_index(t *testing.T) {
@@ -224,7 +261,10 @@ func Test_EqualLines_failure_line_count_mismatch_reports_index(t *testing.T) {
 		`{"id":1}`+"\n"+`{"id":2}`,
 	)
 
-	requireFailure(t, result, "got JSONL line count <1>, wanted <2>; first differing line index <1>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got JSONL line count <1>, wanted <2>; first differing line index <1>")
 }
 
 func Test_EqualLinesWithOptions_failure_invalid_option_reports_line_index(t *testing.T) {
@@ -234,7 +274,10 @@ func Test_EqualLinesWithOptions_failure_invalid_option_reports_line_index(t *tes
 		jsonassert.IgnorePaths("meta."),
 	)
 
-	requireFailure(t, result, "JSONL line <0>: invalid JSON path <meta.>: path ends with dot")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSONL line <0>: invalid JSON path <meta.>: path ends with dot")
 }
 
 func Test_LinesContain_success_full_record(t *testing.T) {
@@ -262,13 +305,19 @@ func Test_LinesContain_failure_no_match(t *testing.T) {
 		`{"id":3}`,
 	)
 
-	requireFailure(t, result, "got no matching JSONL line")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got no matching JSONL line")
 }
 
 func Test_LinesContain_failure_invalid_expected_json(t *testing.T) {
 	result := jsonassert.LinesContain(`{"id":1}`, `{"id":`)
 
-	requireFailure(t, result, "expected JSON invalid:")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "expected JSON invalid:")
 }
 
 func Test_LinesContain_failure_invalid_actual_line(t *testing.T) {
@@ -277,7 +326,10 @@ func Test_LinesContain_failure_invalid_actual_line(t *testing.T) {
 		`{"id":2}`,
 	)
 
-	requireFailure(t, result, "actual JSONL line <1> invalid:")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "actual JSONL line <1> invalid:")
 }
 
 func Test_LinesContain_failure_invalid_option_reports_line_index(t *testing.T) {
@@ -287,7 +339,10 @@ func Test_LinesContain_failure_invalid_option_reports_line_index(t *testing.T) {
 		jsonassert.IgnorePaths("meta."),
 	)
 
-	requireFailure(t, result, "JSONL line <0>: invalid JSON path <meta.>: path ends with dot")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSONL line <0>: invalid JSON path <meta.>: path ends with dot")
 }
 
 func Test_LinesContainSubset_success(t *testing.T) {
@@ -315,7 +370,10 @@ func Test_LinesContainSubset_failure_no_match(t *testing.T) {
 		`{"meta":{"page":1}}`,
 	)
 
-	requireFailure(t, result, "got no JSONL line containing expected subset")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got no JSONL line containing expected subset")
 }
 
 func Test_Valid_success(t *testing.T) {
@@ -327,7 +385,10 @@ func Test_Valid_success(t *testing.T) {
 func Test_Valid_failure(t *testing.T) {
 	result := jsonassert.Valid(`{"name":`)
 
-	requireFailure(t, result, "JSON invalid:")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON invalid:")
 }
 
 func Test_ValidBytes_success(t *testing.T) {
@@ -345,7 +406,10 @@ func Test_ValidReader_success(t *testing.T) {
 func Test_ValidReader_failure_read_error(t *testing.T) {
 	result := jsonassert.ValidReader(errorReader{})
 
-	requireFailure(t, result, "actual JSON read error: read failed")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "actual JSON read error: read failed")
 }
 
 func Test_Contains_success_object_subset(t *testing.T) {
@@ -360,19 +424,28 @@ func Test_Contains_success_object_subset(t *testing.T) {
 func Test_Contains_failure_missing_field(t *testing.T) {
 	result := jsonassert.Contains(`{"status":"ok"}`, `{"meta":{"page":1}}`)
 
-	requireFailure(t, result, "JSON path <$.meta> missing")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON path <$.meta> missing")
 }
 
 func Test_Contains_failure_mismatched_value(t *testing.T) {
 	result := jsonassert.Contains(`{"status":"ok"}`, `{"status":"failed"}`)
 
-	requireFailure(t, result, "JSON path <$.status> mismatch")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON path <$.status> mismatch")
 }
 
 func Test_Contains_failure_array_order_sensitive(t *testing.T) {
 	result := jsonassert.Contains(`{"values":[1,2,3]}`, `{"values":[3,2,1]}`)
 
-	requireFailure(t, result, "JSON path <$.values> mismatch")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON path <$.values> mismatch")
 }
 
 func Test_ContainsBytes_success(t *testing.T) {
@@ -396,13 +469,19 @@ func Test_PathExists_success_array_index(t *testing.T) {
 func Test_PathExists_failure_missing(t *testing.T) {
 	result := jsonassert.PathExists(`{"user":{"name":"Ada"}}`, "user.email")
 
-	requireFailure(t, result, "JSON path <user.email> missing")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON path <user.email> missing")
 }
 
 func Test_PathExists_failure_invalid_path(t *testing.T) {
 	result := jsonassert.PathExists(`{"user":{"name":"Ada"}}`, "user.")
 
-	requireFailure(t, result, "invalid JSON path <user.>: path ends with dot")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "invalid JSON path <user.>: path ends with dot")
 }
 
 func Test_PathMissing_success(t *testing.T) {
@@ -414,7 +493,10 @@ func Test_PathMissing_success(t *testing.T) {
 func Test_PathMissing_failure_exists(t *testing.T) {
 	result := jsonassert.PathMissing(`{"user":{"name":"Ada"}}`, "user.name")
 
-	requireFailure(t, result, "JSON path <user.name> exists, wanted missing")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON path <user.name> exists, wanted missing")
 }
 
 func Test_PathEqual_success(t *testing.T) {
@@ -426,9 +508,12 @@ func Test_PathEqual_success(t *testing.T) {
 func Test_PathEqual_failure_mismatch(t *testing.T) {
 	result := jsonassert.PathEqual(`{"user":{"name":"Ada"}}`, "user.name", `"Grace"`)
 
-	requireFailure(t, result, "JSON path <user.name> mismatch (-want +got):")
-	requireFailure(t, result, "Grace")
-	requireFailure(t, result, "Ada")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON path <user.name> mismatch (-want +got):")
+	aSpy.HadErrorContaining(t, "Grace")
+	aSpy.HadErrorContaining(t, "Ada")
 }
 
 func Test_PathEqualBytes_success(t *testing.T) {
@@ -446,13 +531,19 @@ func Test_ArrayContains_success(t *testing.T) {
 func Test_ArrayContains_failure_missing_element(t *testing.T) {
 	result := jsonassert.ArrayContains(`{"items":[{"id":1}]}`, "items", `{"id":2}`)
 
-	requireFailure(t, result, "got no matching element at JSON path <items>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got no matching element at JSON path <items>")
 }
 
 func Test_ArrayContains_failure_non_array_path(t *testing.T) {
 	result := jsonassert.ArrayContains(`{"items":{"id":1}}`, "items", `{"id":1}`)
 
-	requireFailure(t, result, "wanted array")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "wanted array")
 }
 
 func Test_ArrayContainsBytes_success(t *testing.T) {
@@ -484,7 +575,10 @@ func Test_EqualWithOptions_success_ignore_array_item_path(t *testing.T) {
 func Test_EqualWithOptions_failure_invalid_ignore_path(t *testing.T) {
 	result := jsonassert.EqualWithOptions(`{"status":"ok"}`, `{"status":"ok"}`, jsonassert.IgnorePaths("meta."))
 
-	requireFailure(t, result, "invalid JSON path <meta.>: path ends with dot")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "invalid JSON path <meta.>: path ends with dot")
 }
 
 func Test_EqualWithOptions_success_unordered_array(t *testing.T) {
@@ -514,7 +608,10 @@ func Test_EqualWithOptions_failure_unordered_array_non_array_path(t *testing.T) 
 		jsonassert.UnorderedArraysAt("items"),
 	)
 
-	requireFailure(t, result, "got JSON path <items> type <map[string]interface {}>, wanted array")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got JSON path <items> type <map[string]interface {}>, wanted array")
 }
 
 func Test_EqualWithOptions_failure_without_ignore_paths(t *testing.T) {
@@ -523,7 +620,10 @@ func Test_EqualWithOptions_failure_without_ignore_paths(t *testing.T) {
 		`{"status":"ok","meta":{"request_id":"xyz"}}`,
 	)
 
-	requireFailure(t, result, "JSON mismatch (-want +got):")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "JSON mismatch (-want +got):")
 }
 
 func Test_EqualBytesWithOptions_success(t *testing.T) {
@@ -534,16 +634,6 @@ func Test_EqualBytesWithOptions_success(t *testing.T) {
 		[]byte(`{"tags":["test","go"]}`),
 		jsonassert.UnorderedArraysAt("tags"),
 	))
-}
-
-func requireFailure(t *testing.T, result hammy.AssertionMessage, contains string) {
-	t.Helper()
-	if result.IsSuccessful {
-		t.Fatalf("got success, wanted failure containing %q", contains)
-	}
-	if !strings.Contains(result.Message, contains) {
-		t.Fatalf("got message %q, wanted containing %q", result.Message, contains)
-	}
 }
 
 type errorReader struct{}

--- a/hammy/yamlassert/yamlassert_test.go
+++ b/hammy/yamlassert/yamlassert_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gogunit/gunit/eye"
 	"github.com/gogunit/gunit/hammy"
 	"github.com/gogunit/gunit/hammy/yamlassert"
 )
@@ -25,13 +26,19 @@ func Test_Equal_success_anchor_alias(t *testing.T) {
 func Test_Equal_failure_array_order_mismatch(t *testing.T) {
 	result := yamlassert.Equal("values: [1, 2, 3]\n", "values: [3, 2, 1]\n")
 
-	requireFailure(t, result, "YAML mismatch (-want +got):")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "YAML mismatch (-want +got):")
 }
 
 func Test_Equal_failure_multiple_documents(t *testing.T) {
 	result := yamlassert.Equal("---\nname: Ada\n---\nname: Grace\n", "name: Ada\n")
 
-	requireFailure(t, result, "actual YAML invalid: multiple YAML documents")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "actual YAML invalid: multiple YAML documents")
 }
 
 func Test_EqualBytes_success(t *testing.T) {
@@ -55,13 +62,19 @@ func Test_Valid_success(t *testing.T) {
 func Test_Valid_failure_invalid_yaml(t *testing.T) {
 	result := yamlassert.Valid("name: [Ada\n")
 
-	requireFailure(t, result, "YAML invalid:")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "YAML invalid:")
 }
 
 func Test_Valid_failure_duplicate_key(t *testing.T) {
 	result := yamlassert.Valid("name: Ada\nname: Grace\n")
 
-	requireFailure(t, result, "duplicate YAML key <name>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "duplicate YAML key <name>")
 }
 
 func Test_ValidBytes_success(t *testing.T) {
@@ -79,7 +92,10 @@ func Test_ValidReader_success(t *testing.T) {
 func Test_ValidReader_failure_read_error(t *testing.T) {
 	result := yamlassert.ValidReader(errorReader{})
 
-	requireFailure(t, result, "actual YAML read error: read failed")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "actual YAML read error: read failed")
 }
 
 func Test_Contains_success_mapping_subset(t *testing.T) {
@@ -91,7 +107,10 @@ func Test_Contains_success_mapping_subset(t *testing.T) {
 func Test_Contains_failure_missing_field(t *testing.T) {
 	result := yamlassert.Contains("status: ok\n", "meta:\n  page: 1\n")
 
-	requireFailure(t, result, "YAML path <$.meta> missing")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "YAML path <$.meta> missing")
 }
 
 func Test_ContainsBytes_success(t *testing.T) {
@@ -115,7 +134,10 @@ func Test_PathExists_success_array_index(t *testing.T) {
 func Test_PathExists_failure_missing(t *testing.T) {
 	result := yamlassert.PathExists("user:\n  name: Ada\n", "user.email")
 
-	requireFailure(t, result, "YAML path <user.email> missing")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "YAML path <user.email> missing")
 }
 
 func Test_PathMissing_success(t *testing.T) {
@@ -127,7 +149,10 @@ func Test_PathMissing_success(t *testing.T) {
 func Test_PathMissing_failure_exists(t *testing.T) {
 	result := yamlassert.PathMissing("user:\n  name: Ada\n", "user.name")
 
-	requireFailure(t, result, "YAML path <user.name> exists, wanted missing")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "YAML path <user.name> exists, wanted missing")
 }
 
 func Test_PathEqual_success(t *testing.T) {
@@ -139,9 +164,12 @@ func Test_PathEqual_success(t *testing.T) {
 func Test_PathEqual_failure_mismatch(t *testing.T) {
 	result := yamlassert.PathEqual("user:\n  name: Ada\n", "user.name", "Grace\n")
 
-	requireFailure(t, result, "YAML path <user.name> mismatch (-want +got):")
-	requireFailure(t, result, "Grace")
-	requireFailure(t, result, "Ada")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "YAML path <user.name> mismatch (-want +got):")
+	aSpy.HadErrorContaining(t, "Grace")
+	aSpy.HadErrorContaining(t, "Ada")
 }
 
 func Test_PathEqualBytes_success(t *testing.T) {
@@ -159,7 +187,10 @@ func Test_ArrayContains_success(t *testing.T) {
 func Test_ArrayContains_failure_missing_element(t *testing.T) {
 	result := yamlassert.ArrayContains("items:\n  - id: 1\n", "items", "id: 2\n")
 
-	requireFailure(t, result, "got no matching element at YAML path <items>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got no matching element at YAML path <items>")
 }
 
 func Test_ArrayContainsBytes_success(t *testing.T) {
@@ -207,7 +238,10 @@ func Test_DocumentCount_success(t *testing.T) {
 func Test_DocumentCount_failure(t *testing.T) {
 	result := yamlassert.DocumentCount("---\nname: Ada\n---\nname: Grace\n", 1)
 
-	requireFailure(t, result, "got YAML document count <2>, wanted <1>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got YAML document count <2>, wanted <1>")
 }
 
 func Test_DocumentCountBytes_success(t *testing.T) {
@@ -236,7 +270,10 @@ func Test_DocumentEqual_success_with_options(t *testing.T) {
 func Test_DocumentEqual_failure_index_out_of_range(t *testing.T) {
 	result := yamlassert.DocumentEqual("---\nname: Ada\n", 1, "name: Ada\n")
 
-	requireFailure(t, result, "got YAML document index <1> out of range for count <1>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got YAML document index <1> out of range for count <1>")
 }
 
 func Test_DocumentEqualBytes_success(t *testing.T) {
@@ -255,16 +292,6 @@ func Test_DocumentContainsBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
 	assert.Is(yamlassert.DocumentContainsBytes([]byte("---\nstatus: ok\n"), 0, []byte("status: ok\n")))
-}
-
-func requireFailure(t *testing.T, result hammy.AssertionMessage, contains string) {
-	t.Helper()
-	if result.IsSuccessful {
-		t.Fatalf("got success, wanted failure containing %q", contains)
-	}
-	if !strings.Contains(result.Message, contains) {
-		t.Fatalf("got message %q, wanted containing %q", result.Message, contains)
-	}
 }
 
 type errorReader struct{}


### PR DESCRIPTION
### Motivation

- Standardize how test failures are inspected by replacing the ad-hoc `requireFailure` helper with the existing `eye.Spy` test spy for clearer intent and better integration with `hammy` assertions.
- Eliminate duplicated helper code across multiple test files to reduce maintenance and accidental divergence.
- Remove now-unused imports that were only needed for the helper and streamline test files.

### Description

- Added `github.com/gogunit/gunit/eye` imports to `httpassert_test.go`, `jsonassert_test.go`, and `yamlassert_test.go` and removed the `requireFailure` helper functions from those files.
- Replaced calls like `requireFailure(t, result, "...")` with the spy pattern: `aSpy := eye.Spy(); assert := hammy.New(aSpy); assert.Is(result); aSpy.HadErrorContaining(t, "...")` to assert failure messages.
- Removed now-unused imports (for example `strings` where applicable) and cleaned up the test files accordingly.

### Testing

- Ran `go test ./...` across the repository and the test suite completed successfully.
- All modified tests that inspect assertion failure messages now use `eye.Spy` and passed when run under the test command.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30fc4f7620832daefb562782ef0697)