### PR TITLE
Refactor httpassert API to fluent Response wrapper and update tests/examples

### DIFF
--- a/hammy/httpassert/example_test.go
+++ b/hammy/httpassert/example_test.go
@@ -9,52 +9,52 @@ import (
 	"github.com/gogunit/gunit/hammy/httpassert"
 )
 
-func ExampleStatus() {
-	printExample(httpassert.Status(exampleResponse(http.StatusCreated, nil, ""), http.StatusCreated))
+func ExampleResp_Status() {
+	printExample(httpassert.Response(exampleResponse(http.StatusCreated, nil, "")).Status(http.StatusCreated))
 	// Output:
 	// message="got status <201>, wanted <201>"
 	// success=true
 }
 
-func ExampleStatusInRange() {
-	printExample(httpassert.StatusInRange(exampleResponse(http.StatusNoContent, nil, ""), 200, 299))
+func ExampleResp_StatusInRange() {
+	printExample(httpassert.Response(exampleResponse(http.StatusNoContent, nil, "")).StatusInRange(200, 299))
 	// Output:
 	// message="got status <204>, wanted in range <200..299>"
 	// success=true
 }
 
-func ExampleHeader() {
+func ExampleResp_Header() {
 	resp := exampleResponse(http.StatusOK, http.Header{"Content-Type": {"application/json"}}, "")
-	printExample(httpassert.Header(resp, "Content-Type", "application/json"))
+	printExample(httpassert.Response(resp).Header("Content-Type", "application/json"))
 	// Output:
 	// message="got header <Content-Type>=<application/json>, wanted <application/json>"
 	// success=true
 }
 
-func ExampleHeaderContains() {
+func ExampleResp_HeaderContains() {
 	resp := exampleResponse(http.StatusOK, http.Header{"Content-Type": {"application/json; charset=utf-8"}}, "")
-	printExample(httpassert.HeaderContains(resp, "Content-Type", "application/json"))
+	printExample(httpassert.Response(resp).HeaderContains("Content-Type", "application/json"))
 	// Output:
 	// message="got header <Content-Type>=<application/json; charset=utf-8>, wanted containing <application/json>"
 	// success=true
 }
 
-func ExampleBodyEqual() {
-	printExample(httpassert.BodyEqual(exampleResponse(http.StatusOK, nil, "hello world"), "hello world"))
+func ExampleResp_BodyEqual() {
+	printExample(httpassert.Response(exampleResponse(http.StatusOK, nil, "hello world")).BodyEqual("hello world"))
 	// Output:
 	// message="got body <hello world>, wanted equal to <hello world>"
 	// success=true
 }
 
-func ExampleBodyContains() {
-	printExample(httpassert.BodyContains(exampleResponse(http.StatusOK, nil, "hello world"), "world"))
+func ExampleResp_BodyContains() {
+	printExample(httpassert.Response(exampleResponse(http.StatusOK, nil, "hello world")).BodyContains("world"))
 	// Output:
 	// message="got body <hello world>, wanted containing <world>"
 	// success=true
 }
 
-func ExampleBodyMatchesRegexp() {
-	printExample(httpassert.BodyMatchesRegexp(exampleResponse(http.StatusOK, nil, "status 204"), `status \d+`))
+func ExampleResp_BodyMatchesRegexp() {
+	printExample(httpassert.Response(exampleResponse(http.StatusOK, nil, "status 204")).BodyMatchesRegexp(`status \d+`))
 	// Output:
 	// message="got body <status 204>, wanted regexp <status \\d+>"
 	// success=true

--- a/hammy/httpassert/httpassert.go
+++ b/hammy/httpassert/httpassert.go
@@ -10,14 +10,24 @@ import (
 	"github.com/gogunit/gunit/hammy"
 )
 
-func Status(resp *http.Response, expected int) hammy.AssertionMessage {
+func Response(resp *http.Response) *Resp {
+	return &Resp{actual: resp}
+}
+
+type Resp struct {
+	actual *http.Response
+}
+
+func (r *Resp) Status(expected int) hammy.AssertionMessage {
+	resp := r.response()
 	if resp == nil {
 		return hammy.Assert(false, "got nil response, wanted status <%d>", expected)
 	}
 	return hammy.Assert(resp.StatusCode == expected, "got status <%d>, wanted <%d>", resp.StatusCode, expected)
 }
 
-func StatusInRange(resp *http.Response, min, max int) hammy.AssertionMessage {
+func (r *Resp) StatusInRange(min, max int) hammy.AssertionMessage {
+	resp := r.response()
 	if min > max {
 		return hammy.Assert(false, "got invalid status range <%d..%d>", min, max)
 	}
@@ -27,7 +37,8 @@ func StatusInRange(resp *http.Response, min, max int) hammy.AssertionMessage {
 	return hammy.Assert(resp.StatusCode >= min && resp.StatusCode <= max, "got status <%d>, wanted in range <%d..%d>", resp.StatusCode, min, max)
 }
 
-func Header(resp *http.Response, key, expected string) hammy.AssertionMessage {
+func (r *Resp) Header(key, expected string) hammy.AssertionMessage {
+	resp := r.response()
 	if resp == nil {
 		return hammy.Assert(false, "got nil response, wanted header <%s> equal to <%s>", key, expected)
 	}
@@ -35,7 +46,8 @@ func Header(resp *http.Response, key, expected string) hammy.AssertionMessage {
 	return hammy.Assert(actual == expected, "got header <%s>=<%s>, wanted <%s>", key, actual, expected)
 }
 
-func HeaderContains(resp *http.Response, key, expected string) hammy.AssertionMessage {
+func (r *Resp) HeaderContains(key, expected string) hammy.AssertionMessage {
+	resp := r.response()
 	if resp == nil {
 		return hammy.Assert(false, "got nil response, wanted header <%s> containing <%s>", key, expected)
 	}
@@ -43,24 +55,24 @@ func HeaderContains(resp *http.Response, key, expected string) hammy.AssertionMe
 	return hammy.Assert(strings.Contains(actual, expected), "got header <%s>=<%s>, wanted containing <%s>", key, actual, expected)
 }
 
-func BodyEqual(resp *http.Response, expected string) hammy.AssertionMessage {
-	actual, result := readBody(resp)
+func (r *Resp) BodyEqual(expected string) hammy.AssertionMessage {
+	actual, result := readBody(r.response())
 	if !result.IsSuccessful {
 		return result
 	}
 	return hammy.Assert(actual == expected, "got body <%s>, wanted equal to <%s>", actual, expected)
 }
 
-func BodyContains(resp *http.Response, expected string) hammy.AssertionMessage {
-	actual, result := readBody(resp)
+func (r *Resp) BodyContains(expected string) hammy.AssertionMessage {
+	actual, result := readBody(r.response())
 	if !result.IsSuccessful {
 		return result
 	}
 	return hammy.Assert(strings.Contains(actual, expected), "got body <%s>, wanted containing <%s>", actual, expected)
 }
 
-func BodyMatchesRegexp(resp *http.Response, pattern string) hammy.AssertionMessage {
-	actual, result := readBody(resp)
+func (r *Resp) BodyMatchesRegexp(pattern string) hammy.AssertionMessage {
+	actual, result := readBody(r.response())
 	if !result.IsSuccessful {
 		return result
 	}
@@ -70,6 +82,13 @@ func BodyMatchesRegexp(resp *http.Response, pattern string) hammy.AssertionMessa
 		return hammy.Assert(false, "invalid regexp <%s>: %v", pattern, err)
 	}
 	return hammy.Assert(re.MatchString(actual), "got body <%s>, wanted regexp <%s>", actual, pattern)
+}
+
+func (r *Resp) response() *http.Response {
+	if r == nil {
+		return nil
+	}
+	return r.actual
 }
 
 func readBody(resp *http.Response) (string, hammy.AssertionMessage) {

--- a/hammy/httpassert/httpassert_test.go
+++ b/hammy/httpassert/httpassert_test.go
@@ -22,17 +22,19 @@ func Test_Status_success(t *testing.T) {
 func Test_Status_failure(t *testing.T) {
 	result := httpassert.Response(newResponse(http.StatusCreated, nil, "")).Status(http.StatusOK)
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got status <201>, wanted <200>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got status <201>, wanted <200>")
 }
 
 func Test_Status_failure_nil_response(t *testing.T) {
 	result := httpassert.Response(nil).Status(http.StatusOK)
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got nil response")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got nil response")
 }
 
 func Test_StatusInRange_success(t *testing.T) {
@@ -45,17 +47,19 @@ func Test_StatusInRange_success(t *testing.T) {
 func Test_StatusInRange_failure(t *testing.T) {
 	result := httpassert.Response(newResponse(http.StatusBadRequest, nil, "")).StatusInRange(200, 299)
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got status <400>, wanted in range <200..299>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got status <400>, wanted in range <200..299>")
 }
 
 func Test_StatusInRange_failure_invalid_range(t *testing.T) {
 	result := httpassert.Response(newResponse(http.StatusOK, nil, "")).StatusInRange(299, 200)
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got invalid status range <299..200>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got invalid status range <299..200>")
 }
 
 func Test_Header_success(t *testing.T) {
@@ -69,9 +73,10 @@ func Test_Header_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, http.Header{"Content-Type": {"text/plain"}}, "")
 	result := httpassert.Response(resp).Header("Content-Type", "application/json")
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got header <Content-Type>=<text/plain>, wanted <application/json>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got header <Content-Type>=<text/plain>, wanted <application/json>")
 }
 
 func Test_HeaderContains_success(t *testing.T) {
@@ -85,9 +90,10 @@ func Test_HeaderContains_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, http.Header{"Content-Type": {"text/plain"}}, "")
 	result := httpassert.Response(resp).HeaderContains("Content-Type", "application/json")
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got header <Content-Type>=<text/plain>, wanted containing <application/json>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got header <Content-Type>=<text/plain>, wanted containing <application/json>")
 }
 
 func Test_BodyEqual_success(t *testing.T) {
@@ -101,9 +107,10 @@ func Test_BodyEqual_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "hello world")
 	result := httpassert.Response(resp).BodyEqual("goodbye")
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got body <hello world>, wanted equal to <goodbye>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got body <hello world>, wanted equal to <goodbye>")
 }
 
 func Test_BodyContains_success(t *testing.T) {
@@ -117,9 +124,10 @@ func Test_BodyContains_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "hello world")
 	result := httpassert.Response(resp).BodyContains("goodbye")
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got body <hello world>, wanted containing <goodbye>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got body <hello world>, wanted containing <goodbye>")
 }
 
 func Test_BodyMatchesRegexp_success(t *testing.T) {
@@ -133,18 +141,20 @@ func Test_BodyMatchesRegexp_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "status 204")
 	result := httpassert.Response(resp).BodyMatchesRegexp(`status 5\d\d`)
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got body <status 204>, wanted regexp <status 5\\d\\d>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got body <status 204>, wanted regexp <status 5\\d\\d>")
 }
 
 func Test_BodyMatchesRegexp_failure_invalid_pattern(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "status 204")
 	result := httpassert.Response(resp).BodyMatchesRegexp(`(`)
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "invalid regexp <(>")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "invalid regexp <(>")
 }
 
 func Test_Body_assertions_restore_body(t *testing.T) {
@@ -159,18 +169,20 @@ func Test_Body_assertions_restore_body(t *testing.T) {
 func Test_Body_assertion_failure_nil_response(t *testing.T) {
 	result := httpassert.Response(nil).BodyEqual("hello")
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got nil response")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got nil response")
 }
 
 func Test_Body_assertion_failure_read_error(t *testing.T) {
 	resp := &http.Response{Body: errorReadCloser{}}
 	result := httpassert.Response(resp).BodyEqual("hello")
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got body read error: read failed")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got body read error: read failed")
 }
 
 func newResponse(status int, headers http.Header, body string) *http.Response {
@@ -201,7 +213,8 @@ func Test_Response_methods_failure_nil_receiver(t *testing.T) {
 	var resp *httpassert.Resp
 	result := resp.Status(http.StatusOK)
 
-	spy := eye.Spy()
-	hammy.New(spy).Is(result)
-	spy.HadErrorContaining(t, "got nil response")
+	aSpy := eye.Spy()
+	assert := hammy.New(aSpy)
+	assert.Is(result)
+	aSpy.HadErrorContaining(t, "got nil response")
 }

--- a/hammy/httpassert/httpassert_test.go
+++ b/hammy/httpassert/httpassert_test.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	"github.com/gogunit/gunit/eye"
 	"github.com/gogunit/gunit/hammy"
 	"github.com/gogunit/gunit/hammy/httpassert"
 )
@@ -16,137 +16,161 @@ func Test_Status_success(t *testing.T) {
 	assert := hammy.New(t)
 	resp := newResponse(http.StatusCreated, nil, "")
 
-	assert.Is(httpassert.Status(resp, http.StatusCreated))
+	assert.Is(httpassert.Response(resp).Status(http.StatusCreated))
 }
 
 func Test_Status_failure(t *testing.T) {
-	result := httpassert.Status(newResponse(http.StatusCreated, nil, ""), http.StatusOK)
+	result := httpassert.Response(newResponse(http.StatusCreated, nil, "")).Status(http.StatusOK)
 
-	requireFailure(t, result, "got status <201>, wanted <200>")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got status <201>, wanted <200>")
 }
 
 func Test_Status_failure_nil_response(t *testing.T) {
-	result := httpassert.Status(nil, http.StatusOK)
+	result := httpassert.Response(nil).Status(http.StatusOK)
 
-	requireFailure(t, result, "got nil response")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got nil response")
 }
 
 func Test_StatusInRange_success(t *testing.T) {
 	assert := hammy.New(t)
 	resp := newResponse(http.StatusNoContent, nil, "")
 
-	assert.Is(httpassert.StatusInRange(resp, 200, 299))
+	assert.Is(httpassert.Response(resp).StatusInRange(200, 299))
 }
 
 func Test_StatusInRange_failure(t *testing.T) {
-	result := httpassert.StatusInRange(newResponse(http.StatusBadRequest, nil, ""), 200, 299)
+	result := httpassert.Response(newResponse(http.StatusBadRequest, nil, "")).StatusInRange(200, 299)
 
-	requireFailure(t, result, "got status <400>, wanted in range <200..299>")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got status <400>, wanted in range <200..299>")
 }
 
 func Test_StatusInRange_failure_invalid_range(t *testing.T) {
-	result := httpassert.StatusInRange(newResponse(http.StatusOK, nil, ""), 299, 200)
+	result := httpassert.Response(newResponse(http.StatusOK, nil, "")).StatusInRange(299, 200)
 
-	requireFailure(t, result, "got invalid status range <299..200>")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got invalid status range <299..200>")
 }
 
 func Test_Header_success(t *testing.T) {
 	assert := hammy.New(t)
 	resp := newResponse(http.StatusOK, http.Header{"Content-Type": {"application/json"}}, "")
 
-	assert.Is(httpassert.Header(resp, "Content-Type", "application/json"))
+	assert.Is(httpassert.Response(resp).Header("Content-Type", "application/json"))
 }
 
 func Test_Header_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, http.Header{"Content-Type": {"text/plain"}}, "")
-	result := httpassert.Header(resp, "Content-Type", "application/json")
+	result := httpassert.Response(resp).Header("Content-Type", "application/json")
 
-	requireFailure(t, result, "got header <Content-Type>=<text/plain>, wanted <application/json>")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got header <Content-Type>=<text/plain>, wanted <application/json>")
 }
 
 func Test_HeaderContains_success(t *testing.T) {
 	assert := hammy.New(t)
 	resp := newResponse(http.StatusOK, http.Header{"Content-Type": {"application/json; charset=utf-8"}}, "")
 
-	assert.Is(httpassert.HeaderContains(resp, "Content-Type", "application/json"))
+	assert.Is(httpassert.Response(resp).HeaderContains("Content-Type", "application/json"))
 }
 
 func Test_HeaderContains_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, http.Header{"Content-Type": {"text/plain"}}, "")
-	result := httpassert.HeaderContains(resp, "Content-Type", "application/json")
+	result := httpassert.Response(resp).HeaderContains("Content-Type", "application/json")
 
-	requireFailure(t, result, "got header <Content-Type>=<text/plain>, wanted containing <application/json>")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got header <Content-Type>=<text/plain>, wanted containing <application/json>")
 }
 
 func Test_BodyEqual_success(t *testing.T) {
 	assert := hammy.New(t)
 	resp := newResponse(http.StatusOK, nil, "hello world")
 
-	assert.Is(httpassert.BodyEqual(resp, "hello world"))
+	assert.Is(httpassert.Response(resp).BodyEqual("hello world"))
 }
 
 func Test_BodyEqual_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "hello world")
-	result := httpassert.BodyEqual(resp, "goodbye")
+	result := httpassert.Response(resp).BodyEqual("goodbye")
 
-	requireFailure(t, result, "got body <hello world>, wanted equal to <goodbye>")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got body <hello world>, wanted equal to <goodbye>")
 }
 
 func Test_BodyContains_success(t *testing.T) {
 	assert := hammy.New(t)
 	resp := newResponse(http.StatusOK, nil, "hello world")
 
-	assert.Is(httpassert.BodyContains(resp, "world"))
+	assert.Is(httpassert.Response(resp).BodyContains("world"))
 }
 
 func Test_BodyContains_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "hello world")
-	result := httpassert.BodyContains(resp, "goodbye")
+	result := httpassert.Response(resp).BodyContains("goodbye")
 
-	requireFailure(t, result, "got body <hello world>, wanted containing <goodbye>")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got body <hello world>, wanted containing <goodbye>")
 }
 
 func Test_BodyMatchesRegexp_success(t *testing.T) {
 	assert := hammy.New(t)
 	resp := newResponse(http.StatusOK, nil, "status 204")
 
-	assert.Is(httpassert.BodyMatchesRegexp(resp, `status \d+`))
+	assert.Is(httpassert.Response(resp).BodyMatchesRegexp(`status \d+`))
 }
 
 func Test_BodyMatchesRegexp_failure(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "status 204")
-	result := httpassert.BodyMatchesRegexp(resp, `status 5\d\d`)
+	result := httpassert.Response(resp).BodyMatchesRegexp(`status 5\d\d`)
 
-	requireFailure(t, result, "got body <status 204>, wanted regexp <status 5\\d\\d>")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got body <status 204>, wanted regexp <status 5\\d\\d>")
 }
 
 func Test_BodyMatchesRegexp_failure_invalid_pattern(t *testing.T) {
 	resp := newResponse(http.StatusOK, nil, "status 204")
-	result := httpassert.BodyMatchesRegexp(resp, `(`)
+	result := httpassert.Response(resp).BodyMatchesRegexp(`(`)
 
-	requireFailure(t, result, "invalid regexp <(>")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "invalid regexp <(>")
 }
 
 func Test_Body_assertions_restore_body(t *testing.T) {
 	assert := hammy.New(t)
 	resp := newResponse(http.StatusOK, nil, "hello world")
 
-	assert.Is(httpassert.BodyContains(resp, "hello"))
-	assert.Is(httpassert.BodyEqual(resp, "hello world"))
-	assert.Is(httpassert.BodyMatchesRegexp(resp, `world$`))
+	assert.Is(httpassert.Response(resp).BodyContains("hello"))
+	assert.Is(httpassert.Response(resp).BodyEqual("hello world"))
+	assert.Is(httpassert.Response(resp).BodyMatchesRegexp(`world$`))
 }
 
 func Test_Body_assertion_failure_nil_response(t *testing.T) {
-	result := httpassert.BodyEqual(nil, "hello")
+	result := httpassert.Response(nil).BodyEqual("hello")
 
-	requireFailure(t, result, "got nil response")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got nil response")
 }
 
 func Test_Body_assertion_failure_read_error(t *testing.T) {
 	resp := &http.Response{Body: errorReadCloser{}}
-	result := httpassert.BodyEqual(resp, "hello")
+	result := httpassert.Response(resp).BodyEqual("hello")
 
-	requireFailure(t, result, "got body read error: read failed")
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got body read error: read failed")
 }
 
 func newResponse(status int, headers http.Header, body string) *http.Response {
@@ -161,16 +185,6 @@ func newResponse(status int, headers http.Header, body string) *http.Response {
 	return recorder.Result()
 }
 
-func requireFailure(t *testing.T, result hammy.AssertionMessage, contains string) {
-	t.Helper()
-	if result.IsSuccessful {
-		t.Fatalf("got success, wanted failure containing %q", contains)
-	}
-	if !strings.Contains(result.Message, contains) {
-		t.Fatalf("got message %q, wanted containing %q", result.Message, contains)
-	}
-}
-
 type errorReadCloser struct{}
 
 func (errorReadCloser) Read([]byte) (int, error) {
@@ -182,3 +196,12 @@ func (errorReadCloser) Close() error {
 }
 
 var _ io.ReadCloser = errorReadCloser{}
+
+func Test_Response_methods_failure_nil_receiver(t *testing.T) {
+	var resp *httpassert.Resp
+	result := resp.Status(http.StatusOK)
+
+	spy := eye.Spy()
+	hammy.New(spy).Is(result)
+	spy.HadErrorContaining(t, "got nil response")
+}


### PR DESCRIPTION
### Motivation
- Provide a more ergonomic, chainable API for HTTP assertions by moving from standalone functions to a `Response` wrapper with methods. 
- Improve nil-safety for receiver usage and streamline example/test usage to the new fluent API.

### Description
- Introduce `Resp` type and `Response(resp *http.Response) *Resp` constructor and implement methods `Status`, `StatusInRange`, `Header`, `HeaderContains`, `BodyEqual`, `BodyContains`, and `BodyMatchesRegexp` on it. 
- Add a nil-safe helper `response()` on `Resp` so method calls on a nil receiver return appropriate assertion failures. 
- Update `readBody` to be reused by the new methods without behavioral changes. 
- Update examples in `example_test.go` and all tests in `httpassert_test.go` to use the new `httpassert.Response(...).<Method>` form and rename example functions accordingly. 
- Replace the old `requireFailure` helper with assertions via `eye.Spy` in tests and add `Test_Response_methods_failure_nil_receiver` to verify nil-receiver behavior.

### Testing
- Ran package tests with `go test ./hammy/httpassert` and `go test ./...` and the test suite succeeded. 
- Verified the new `Test_Response_methods_failure_nil_receiver` passes and failure cases are asserted via `eye.Spy` as expected. 
- Examples output updated and validated via the example tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30edd250ec832daf7a09f21afca783)