### PR TITLE
Add jsonassert receiver API

### DIFF
--- a/hammy/README.md
+++ b/hammy/README.md
@@ -132,33 +132,33 @@ func Test_payload_has_expected_type(t *testing.T) {
 
 ## JSON (`hammy/jsonassert`)
 
-* [x] Reader
-* [x] Bytes
 * [x] String
-* [x] ArrayContains
-* [x] ArrayContainsBytes
-* [x] Contains
-* [x] ContainsBytes
-* [x] Equal
-* [x] EqualBytes
-* [x] EqualBytesWithOptions
-* [x] EqualLines
-* [x] EqualLinesBytes
-* [x] EqualLinesBytesWithOptions
-* [x] EqualLinesWithOptions
-* [x] EqualReader
-* [x] EqualWithOptions
+  * [x] EqualTo
+  * [x] EqualToWithOptions
+  * [x] LinesEqualTo
+  * [x] LinesEqualToWithOptions
+  * [x] LinesContain
+  * [x] LinesContainSubset
+  * [x] IsValid
+  * [x] Contains
+  * [x] PathExists
+  * [x] PathMissing
+  * [x] PathEqual
+  * [x] ArrayContains
+* [x] Bytes
+  * [x] EqualTo
+  * [x] EqualToWithOptions
+  * [x] LinesEqualTo
+  * [x] LinesEqualToWithOptions
+  * [x] IsValid
+  * [x] Contains
+  * [x] PathEqual
+  * [x] ArrayContains
+* [x] Reader
+  * [x] EqualTo
+  * [x] IsValid
 * [x] IgnorePaths
-* [x] LinesContain
-* [x] LinesContainSubset
-* [x] PathEqual
-* [x] PathEqualBytes
-* [x] PathExists
-* [x] PathMissing
 * [x] UnorderedArraysAt
-* [x] Valid
-* [x] ValidBytes
-* [x] ValidReader
 
 ## YAML (`hammy/yamlassert`)
 

--- a/hammy/README.md
+++ b/hammy/README.md
@@ -58,9 +58,9 @@ Use `jsonassert` for semantic JSON equality that ignores object key order and in
 ```go
 import ja "github.com/gogunit/gunit/hammy/jsonassert"
 
-assert.Is(ja.Equal(actualJSON, expectedJSON))
-assert.Is(ja.PathEqual(actualJSON, "user.name", `"Ada"`))
-assert.Is(ja.EqualWithOptions(actualJSON, expectedJSON, ja.IgnorePaths("meta.request_id")))
+assert.Is(ja.String(actualJSON).EqualTo(expectedJSON))
+assert.Is(ja.String(actualJSON).PathEqual("user.name", `"Ada"`))
+assert.Is(ja.String(actualJSON).EqualToWithOptions(expectedJSON, ja.IgnorePaths("meta.request_id")))
 ```
 
 Use `yamlassert` for semantic YAML equality, path checks, and multi-document streams:
@@ -132,6 +132,9 @@ func Test_payload_has_expected_type(t *testing.T) {
 
 ## JSON (`hammy/jsonassert`)
 
+* [x] Reader
+* [x] Bytes
+* [x] String
 * [x] ArrayContains
 * [x] ArrayContainsBytes
 * [x] Contains

--- a/hammy/jsonassert/example_test.go
+++ b/hammy/jsonassert/example_test.go
@@ -15,7 +15,7 @@ func ExampleEqual() {
 		"age": 37
 	}`
 
-	printExample(jsonassert.Equal(actual, expected))
+	printExample(jsonassert.String(actual).EqualTo(expected))
 	// Output:
 	// message="JSON mismatch (-want +got):\n"
 	// success=true
@@ -25,7 +25,7 @@ func ExampleEqual_reorderedObjectKeys() {
 	actual := `{"name":"Ada","age":37}`
 	expected := `{"age":37,"name":"Ada"}`
 
-	printExample(jsonassert.Equal(actual, expected))
+	printExample(jsonassert.String(actual).EqualTo(expected))
 	// Output:
 	// message="JSON mismatch (-want +got):\n"
 	// success=true
@@ -35,7 +35,7 @@ func ExampleEqualWithOptions() {
 	actual := `{"status":"ok","meta":{"request_id":"abc"}}`
 	expected := `{"status":"ok","meta":{"request_id":"xyz"}}`
 
-	printExample(jsonassert.EqualWithOptions(actual, expected, jsonassert.IgnorePaths("meta.request_id")))
+	printExample(jsonassert.String(actual).EqualToWithOptions(expected, jsonassert.IgnorePaths("meta.request_id")))
 	// Output:
 	// message="JSON mismatch (-want +got):\n"
 	// success=true
@@ -45,7 +45,7 @@ func ExampleEqualLines() {
 	actual := `{"name":"Ada","age":37}` + "\n" + `{"name":"Grace","age":85}`
 	expected := `{"age":37.0,"name":"Ada"}` + "\n" + `{"age":85.0,"name":"Grace"}`
 
-	printExample(jsonassert.EqualLines(actual, expected))
+	printExample(jsonassert.String(actual).LinesEqualTo(expected))
 	// Output:
 	// message="JSONL mismatch (-want +got):\n"
 	// success=true
@@ -55,7 +55,7 @@ func ExampleEqualLinesWithOptions() {
 	actual := `{"status":"ok","meta":{"request_id":"abc"}}` + "\n" + `{"status":"ok","meta":{"request_id":"def"}}`
 	expected := `{"status":"ok","meta":{"request_id":"uvw"}}` + "\n" + `{"status":"ok","meta":{"request_id":"xyz"}}`
 
-	printExample(jsonassert.EqualLinesWithOptions(actual, expected, jsonassert.IgnorePaths("meta.request_id")))
+	printExample(jsonassert.String(actual).LinesEqualToWithOptions(expected, jsonassert.IgnorePaths("meta.request_id")))
 	// Output:
 	// message="JSONL mismatch (-want +got):\n"
 	// success=true
@@ -65,7 +65,7 @@ func ExampleEqualLinesBytes() {
 	actual := []byte(`{"id":1}` + "\n" + `{"id":2}`)
 	expected := []byte(`{"id":1.0}` + "\n" + `{"id":2.0}`)
 
-	printExample(jsonassert.EqualLinesBytes(actual, expected))
+	printExample(jsonassert.Bytes(actual).LinesEqualTo(expected))
 	// Output:
 	// message="JSONL mismatch (-want +got):\n"
 	// success=true
@@ -75,7 +75,7 @@ func ExampleEqualLinesBytesWithOptions() {
 	actual := []byte(`{"tags":["go","test"]}` + "\n" + `{"tags":["json","assert"]}`)
 	expected := []byte(`{"tags":["test","go"]}` + "\n" + `{"tags":["assert","json"]}`)
 
-	printExample(jsonassert.EqualLinesBytesWithOptions(actual, expected, jsonassert.UnorderedArraysAt("tags")))
+	printExample(jsonassert.Bytes(actual).LinesEqualToWithOptions(expected, jsonassert.UnorderedArraysAt("tags")))
 	// Output:
 	// message="JSONL mismatch (-want +got):\n"
 	// success=true
@@ -85,7 +85,7 @@ func ExampleEqualBytes() {
 	actual := []byte(`{"one":1}`)
 	expected := []byte(`{"one":1.0}`)
 
-	printExample(jsonassert.EqualBytes(actual, expected))
+	printExample(jsonassert.Bytes(actual).EqualTo(expected))
 	// Output:
 	// message="JSON mismatch (-want +got):\n"
 	// success=true
@@ -95,7 +95,7 @@ func ExampleEqualBytesWithOptions() {
 	actual := []byte(`{"tags":["go","test"]}`)
 	expected := []byte(`{"tags":["test","go"]}`)
 
-	printExample(jsonassert.EqualBytesWithOptions(actual, expected, jsonassert.UnorderedArraysAt("tags")))
+	printExample(jsonassert.Bytes(actual).EqualToWithOptions(expected, jsonassert.UnorderedArraysAt("tags")))
 	// Output:
 	// message="JSON mismatch (-want +got):\n"
 	// success=true
@@ -105,28 +105,28 @@ func ExampleEqualReader() {
 	actual := strings.NewReader(`{"one":1}`)
 	expected := strings.NewReader(`{"one":1.0}`)
 
-	printExample(jsonassert.EqualReader(actual, expected))
+	printExample(jsonassert.Reader(actual).EqualTo(expected))
 	// Output:
 	// message="JSON mismatch (-want +got):\n"
 	// success=true
 }
 
 func ExampleValid() {
-	printExample(jsonassert.Valid(`{"name":"Ada"}`))
+	printExample(jsonassert.String(`{"name":"Ada"}`).IsValid())
 	// Output:
 	// message="got valid JSON"
 	// success=true
 }
 
 func ExampleValidBytes() {
-	printExample(jsonassert.ValidBytes([]byte(`{"name":"Ada"}`)))
+	printExample(jsonassert.Bytes([]byte(`{"name":"Ada"}`)).IsValid())
 	// Output:
 	// message="got valid JSON"
 	// success=true
 }
 
 func ExampleValidReader() {
-	printExample(jsonassert.ValidReader(strings.NewReader(`{"name":"Ada"}`)))
+	printExample(jsonassert.Reader(strings.NewReader(`{"name":"Ada"}`)).IsValid())
 	// Output:
 	// message="got valid JSON"
 	// success=true
@@ -136,7 +136,7 @@ func ExampleContains() {
 	actual := `{"status":"ok","meta":{"page":1,"request_id":"abc"}}`
 	expected := `{"meta":{"page":1.0}}`
 
-	printExample(jsonassert.Contains(actual, expected))
+	printExample(jsonassert.String(actual).Contains(expected))
 	// Output:
 	// message="JSON contained expected subset"
 	// success=true
@@ -146,7 +146,7 @@ func ExampleContainsBytes() {
 	actual := []byte(`{"status":"ok","extra":true}`)
 	expected := []byte(`{"status":"ok"}`)
 
-	printExample(jsonassert.ContainsBytes(actual, expected))
+	printExample(jsonassert.Bytes(actual).Contains(expected))
 	// Output:
 	// message="JSON contained expected subset"
 	// success=true
@@ -155,7 +155,7 @@ func ExampleContainsBytes() {
 func ExampleLinesContain() {
 	actual := `{"id":1,"name":"Ada"}` + "\n" + `{"id":2,"name":"Grace"}`
 
-	printExample(jsonassert.LinesContain(actual, `{"name":"Grace","id":2.0}`))
+	printExample(jsonassert.String(actual).LinesContain(`{"name":"Grace","id":2.0}`))
 	// Output:
 	// message="found matching JSONL line <1>"
 	// success=true
@@ -164,28 +164,28 @@ func ExampleLinesContain() {
 func ExampleLinesContainSubset() {
 	actual := `{"status":"ok","meta":{"page":1,"request_id":"abc"}}` + "\n" + `{"status":"done"}`
 
-	printExample(jsonassert.LinesContainSubset(actual, `{"meta":{"page":1.0}}`))
+	printExample(jsonassert.String(actual).LinesContainSubset(`{"meta":{"page":1.0}}`))
 	// Output:
 	// message="found JSONL line <0> containing expected subset"
 	// success=true
 }
 
 func ExamplePathExists() {
-	printExample(jsonassert.PathExists(`{"user":{"name":"Ada"}}`, "user.name"))
+	printExample(jsonassert.String(`{"user":{"name":"Ada"}}`).PathExists("user.name"))
 	// Output:
 	// message="JSON path <user.name> exists"
 	// success=true
 }
 
 func ExamplePathMissing() {
-	printExample(jsonassert.PathMissing(`{"user":{"name":"Ada"}}`, "user.email"))
+	printExample(jsonassert.String(`{"user":{"name":"Ada"}}`).PathMissing("user.email"))
 	// Output:
 	// message="JSON path <user.email> missing"
 	// success=true
 }
 
 func ExamplePathEqual() {
-	printExample(jsonassert.PathEqual(`{"user":{"age":37}}`, "user.age", `37.0`))
+	printExample(jsonassert.String(`{"user":{"age":37}}`).PathEqual("user.age", `37.0`))
 	// Output:
 	// message="JSON path <user.age> mismatch (-want +got):\n"
 	// success=true
@@ -195,7 +195,7 @@ func ExamplePathEqualBytes() {
 	actual := []byte(`{"user":{"name":"Ada"}}`)
 	expected := []byte(`"Ada"`)
 
-	printExample(jsonassert.PathEqualBytes(actual, "user.name", expected))
+	printExample(jsonassert.Bytes(actual).PathEqual("user.name", expected))
 	// Output:
 	// message="JSON path <user.name> mismatch (-want +got):\n"
 	// success=true
@@ -204,7 +204,7 @@ func ExamplePathEqualBytes() {
 func ExampleArrayContains() {
 	actual := `{"items":[{"id":1},{"id":2}]}`
 
-	printExample(jsonassert.ArrayContains(actual, "items", `{"id":2.0}`))
+	printExample(jsonassert.String(actual).ArrayContains("items", `{"id":2.0}`))
 	// Output:
 	// message="found matching element at JSON path <items> index <1>"
 	// success=true
@@ -214,7 +214,7 @@ func ExampleArrayContainsBytes() {
 	actual := []byte(`{"items":[1,2]}`)
 	expected := []byte(`2.0`)
 
-	printExample(jsonassert.ArrayContainsBytes(actual, "items", expected))
+	printExample(jsonassert.Bytes(actual).ArrayContains("items", expected))
 	// Output:
 	// message="found matching element at JSON path <items> index <1>"
 	// success=true
@@ -224,7 +224,7 @@ func ExampleIgnorePaths() {
 	actual := `{"status":"ok","meta":{"request_id":"abc"}}`
 	expected := `{"status":"ok","meta":{"request_id":"xyz"}}`
 
-	printExample(jsonassert.EqualWithOptions(actual, expected, jsonassert.IgnorePaths("meta.request_id")))
+	printExample(jsonassert.String(actual).EqualToWithOptions(expected, jsonassert.IgnorePaths("meta.request_id")))
 	// Output:
 	// message="JSON mismatch (-want +got):\n"
 	// success=true
@@ -234,7 +234,7 @@ func ExampleUnorderedArraysAt() {
 	actual := `{"tags":["go","test","json"]}`
 	expected := `{"tags":["json","go","test"]}`
 
-	printExample(jsonassert.EqualWithOptions(actual, expected, jsonassert.UnorderedArraysAt("tags")))
+	printExample(jsonassert.String(actual).EqualToWithOptions(expected, jsonassert.UnorderedArraysAt("tags")))
 	// Output:
 	// message="JSON mismatch (-want +got):\n"
 	// success=true

--- a/hammy/jsonassert/example_test.go
+++ b/hammy/jsonassert/example_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gogunit/gunit/hammy/jsonassert"
 )
 
-func ExampleEqual() {
+func ExampleStringAssert_EqualTo() {
 	actual := `{"name":"Ada","age":37}`
 	expected := `{
 		"name": "Ada",
@@ -21,7 +21,7 @@ func ExampleEqual() {
 	// success=true
 }
 
-func ExampleEqual_reorderedObjectKeys() {
+func ExampleStringAssert_EqualTo_reorderedObjectKeys() {
 	actual := `{"name":"Ada","age":37}`
 	expected := `{"age":37,"name":"Ada"}`
 
@@ -31,7 +31,7 @@ func ExampleEqual_reorderedObjectKeys() {
 	// success=true
 }
 
-func ExampleEqualWithOptions() {
+func ExampleStringAssert_EqualToWithOptions() {
 	actual := `{"status":"ok","meta":{"request_id":"abc"}}`
 	expected := `{"status":"ok","meta":{"request_id":"xyz"}}`
 
@@ -41,7 +41,7 @@ func ExampleEqualWithOptions() {
 	// success=true
 }
 
-func ExampleEqualLines() {
+func ExampleStringAssert_LinesEqualTo() {
 	actual := `{"name":"Ada","age":37}` + "\n" + `{"name":"Grace","age":85}`
 	expected := `{"age":37.0,"name":"Ada"}` + "\n" + `{"age":85.0,"name":"Grace"}`
 
@@ -51,7 +51,7 @@ func ExampleEqualLines() {
 	// success=true
 }
 
-func ExampleEqualLinesWithOptions() {
+func ExampleStringAssert_LinesEqualToWithOptions() {
 	actual := `{"status":"ok","meta":{"request_id":"abc"}}` + "\n" + `{"status":"ok","meta":{"request_id":"def"}}`
 	expected := `{"status":"ok","meta":{"request_id":"uvw"}}` + "\n" + `{"status":"ok","meta":{"request_id":"xyz"}}`
 
@@ -61,7 +61,7 @@ func ExampleEqualLinesWithOptions() {
 	// success=true
 }
 
-func ExampleEqualLinesBytes() {
+func ExampleBytesAssert_LinesEqualTo() {
 	actual := []byte(`{"id":1}` + "\n" + `{"id":2}`)
 	expected := []byte(`{"id":1.0}` + "\n" + `{"id":2.0}`)
 
@@ -71,7 +71,7 @@ func ExampleEqualLinesBytes() {
 	// success=true
 }
 
-func ExampleEqualLinesBytesWithOptions() {
+func ExampleBytesAssert_LinesEqualToWithOptions() {
 	actual := []byte(`{"tags":["go","test"]}` + "\n" + `{"tags":["json","assert"]}`)
 	expected := []byte(`{"tags":["test","go"]}` + "\n" + `{"tags":["assert","json"]}`)
 
@@ -81,7 +81,7 @@ func ExampleEqualLinesBytesWithOptions() {
 	// success=true
 }
 
-func ExampleEqualBytes() {
+func ExampleBytesAssert_EqualTo() {
 	actual := []byte(`{"one":1}`)
 	expected := []byte(`{"one":1.0}`)
 
@@ -91,7 +91,7 @@ func ExampleEqualBytes() {
 	// success=true
 }
 
-func ExampleEqualBytesWithOptions() {
+func ExampleBytesAssert_EqualToWithOptions() {
 	actual := []byte(`{"tags":["go","test"]}`)
 	expected := []byte(`{"tags":["test","go"]}`)
 
@@ -101,7 +101,7 @@ func ExampleEqualBytesWithOptions() {
 	// success=true
 }
 
-func ExampleEqualReader() {
+func ExampleReaderAssert_EqualTo() {
 	actual := strings.NewReader(`{"one":1}`)
 	expected := strings.NewReader(`{"one":1.0}`)
 
@@ -111,28 +111,28 @@ func ExampleEqualReader() {
 	// success=true
 }
 
-func ExampleValid() {
+func ExampleStringAssert_IsValid() {
 	printExample(jsonassert.String(`{"name":"Ada"}`).IsValid())
 	// Output:
 	// message="got valid JSON"
 	// success=true
 }
 
-func ExampleValidBytes() {
+func ExampleBytesAssert_IsValid() {
 	printExample(jsonassert.Bytes([]byte(`{"name":"Ada"}`)).IsValid())
 	// Output:
 	// message="got valid JSON"
 	// success=true
 }
 
-func ExampleValidReader() {
+func ExampleReaderAssert_IsValid() {
 	printExample(jsonassert.Reader(strings.NewReader(`{"name":"Ada"}`)).IsValid())
 	// Output:
 	// message="got valid JSON"
 	// success=true
 }
 
-func ExampleContains() {
+func ExampleStringAssert_Contains() {
 	actual := `{"status":"ok","meta":{"page":1,"request_id":"abc"}}`
 	expected := `{"meta":{"page":1.0}}`
 
@@ -142,7 +142,7 @@ func ExampleContains() {
 	// success=true
 }
 
-func ExampleContainsBytes() {
+func ExampleBytesAssert_Contains() {
 	actual := []byte(`{"status":"ok","extra":true}`)
 	expected := []byte(`{"status":"ok"}`)
 
@@ -152,7 +152,7 @@ func ExampleContainsBytes() {
 	// success=true
 }
 
-func ExampleLinesContain() {
+func ExampleStringAssert_LinesContain() {
 	actual := `{"id":1,"name":"Ada"}` + "\n" + `{"id":2,"name":"Grace"}`
 
 	printExample(jsonassert.String(actual).LinesContain(`{"name":"Grace","id":2.0}`))
@@ -161,7 +161,7 @@ func ExampleLinesContain() {
 	// success=true
 }
 
-func ExampleLinesContainSubset() {
+func ExampleStringAssert_LinesContainSubset() {
 	actual := `{"status":"ok","meta":{"page":1,"request_id":"abc"}}` + "\n" + `{"status":"done"}`
 
 	printExample(jsonassert.String(actual).LinesContainSubset(`{"meta":{"page":1.0}}`))
@@ -170,28 +170,28 @@ func ExampleLinesContainSubset() {
 	// success=true
 }
 
-func ExamplePathExists() {
+func ExampleStringAssert_PathExists() {
 	printExample(jsonassert.String(`{"user":{"name":"Ada"}}`).PathExists("user.name"))
 	// Output:
 	// message="JSON path <user.name> exists"
 	// success=true
 }
 
-func ExamplePathMissing() {
+func ExampleStringAssert_PathMissing() {
 	printExample(jsonassert.String(`{"user":{"name":"Ada"}}`).PathMissing("user.email"))
 	// Output:
 	// message="JSON path <user.email> missing"
 	// success=true
 }
 
-func ExamplePathEqual() {
+func ExampleStringAssert_PathEqual() {
 	printExample(jsonassert.String(`{"user":{"age":37}}`).PathEqual("user.age", `37.0`))
 	// Output:
 	// message="JSON path <user.age> mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExamplePathEqualBytes() {
+func ExampleBytesAssert_PathEqual() {
 	actual := []byte(`{"user":{"name":"Ada"}}`)
 	expected := []byte(`"Ada"`)
 
@@ -201,7 +201,7 @@ func ExamplePathEqualBytes() {
 	// success=true
 }
 
-func ExampleArrayContains() {
+func ExampleStringAssert_ArrayContains() {
 	actual := `{"items":[{"id":1},{"id":2}]}`
 
 	printExample(jsonassert.String(actual).ArrayContains("items", `{"id":2.0}`))
@@ -210,7 +210,7 @@ func ExampleArrayContains() {
 	// success=true
 }
 
-func ExampleArrayContainsBytes() {
+func ExampleBytesAssert_ArrayContains() {
 	actual := []byte(`{"items":[1,2]}`)
 	expected := []byte(`2.0`)
 

--- a/hammy/jsonassert/jsonassert.go
+++ b/hammy/jsonassert/jsonassert.go
@@ -38,24 +38,6 @@ func Reader(actual io.Reader) *ReaderAssert {
 	return &ReaderAssert{actual: actual}
 }
 
-func Equal(a, e string) hammy.AssertionMessage { return String(a).EqualTo(e) }
-
-func EqualWithOptions(actual, expected string, opts ...Option) hammy.AssertionMessage {
-	return String(actual).EqualToWithOptions(expected, opts...)
-}
-
-func EqualLines(a, e string) hammy.AssertionMessage { return String(a).LinesEqualTo(e) }
-
-func EqualLinesWithOptions(actual, expected string, opts ...Option) hammy.AssertionMessage {
-	return String(actual).LinesEqualToWithOptions(expected, opts...)
-}
-
-func EqualLinesBytes(a, e []byte) hammy.AssertionMessage { return Bytes(a).LinesEqualTo(e) }
-
-func EqualLinesBytesWithOptions(actual, expected []byte, opts ...Option) hammy.AssertionMessage {
-	return Bytes(actual).LinesEqualToWithOptions(expected, opts...)
-}
-
 func (assert *BytesAssert) LinesEqualToWithOptions(expected []byte, opts ...Option) hammy.AssertionMessage {
 	actual := assert.actual
 	actualLines := splitJSONLines(string(actual))
@@ -92,22 +74,6 @@ func (assert *BytesAssert) LinesEqualToWithOptions(expected []byte, opts ...Opti
 	}
 
 	return hammy.Assert(true, "JSONL mismatch (-want +got):\n")
-}
-
-func LinesContain(actual, expected string, opts ...Option) hammy.AssertionMessage {
-	return String(actual).LinesContain(expected, opts...)
-}
-
-func LinesContainSubset(actual, expected string, opts ...Option) hammy.AssertionMessage {
-	return String(actual).LinesContainSubset(expected, opts...)
-}
-
-func EqualReader(a, e io.Reader) hammy.AssertionMessage { return Reader(a).EqualTo(e) }
-
-func EqualBytes(a, e []byte) hammy.AssertionMessage { return Bytes(a).EqualTo(e) }
-
-func EqualBytesWithOptions(actual, expected []byte, opts ...Option) hammy.AssertionMessage {
-	return Bytes(actual).EqualToWithOptions(expected, opts...)
 }
 
 func (assert *BytesAssert) EqualToWithOptions(expected []byte, opts ...Option) hammy.AssertionMessage {
@@ -224,22 +190,6 @@ type compareOptions struct {
 	unorderedArrayPaths []string
 }
 
-func Valid(actual string) hammy.AssertionMessage {
-	return String(actual).IsValid()
-}
-
-func ValidReader(actual io.Reader) hammy.AssertionMessage {
-	return Reader(actual).IsValid()
-}
-
-func ValidBytes(actual []byte) hammy.AssertionMessage {
-	return Bytes(actual).IsValid()
-}
-
-func Contains(a, e string) hammy.AssertionMessage { return String(a).Contains(e) }
-
-func ContainsBytes(a, e []byte) hammy.AssertionMessage { return Bytes(a).Contains(e) }
-
 func (assert *BytesAssert) Contains(expected []byte) hammy.AssertionMessage {
 	actual := assert.actual
 	actualJSON, err := parseJSON(actual)
@@ -258,10 +208,6 @@ func (assert *BytesAssert) Contains(expected []byte) hammy.AssertionMessage {
 	return hammy.Assert(true, "JSON contained expected subset")
 }
 
-func PathExists(actual, path string) hammy.AssertionMessage {
-	return String(actual).PathExists(path)
-}
-
 func (assert *StringAssert) PathExists(path string) hammy.AssertionMessage {
 	actualJSON, err := parseJSON([]byte(assert.actual))
 	if err != nil {
@@ -274,10 +220,6 @@ func (assert *StringAssert) PathExists(path string) hammy.AssertionMessage {
 		return hammy.Assert(false, "JSON path <%s> missing", path)
 	}
 	return hammy.Assert(true, "JSON path <%s> exists", path)
-}
-
-func PathMissing(actual, path string) hammy.AssertionMessage {
-	return String(actual).PathMissing(path)
 }
 
 func (assert *StringAssert) PathMissing(path string) hammy.AssertionMessage {
@@ -294,16 +236,8 @@ func (assert *StringAssert) PathMissing(path string) hammy.AssertionMessage {
 	return hammy.Assert(true, "JSON path <%s> missing", path)
 }
 
-func PathEqual(actual, path, expected string) hammy.AssertionMessage {
-	return String(actual).PathEqual(path, expected)
-}
-
 func (assert *StringAssert) PathEqual(path, expected string) hammy.AssertionMessage {
 	return Bytes([]byte(assert.actual)).PathEqual(path, []byte(expected))
-}
-
-func PathEqualBytes(actual []byte, path string, expected []byte) hammy.AssertionMessage {
-	return Bytes(actual).PathEqual(path, expected)
 }
 
 func (assert *BytesAssert) PathEqual(path string, expected []byte) hammy.AssertionMessage {
@@ -330,16 +264,8 @@ func (assert *BytesAssert) PathEqual(path string, expected []byte) hammy.Asserti
 	return hammy.Assert(diff == "", "JSON path <%s> mismatch (-want +got):\n%s", path, diff)
 }
 
-func ArrayContains(actual, path, expectedElement string) hammy.AssertionMessage {
-	return String(actual).ArrayContains(path, expectedElement)
-}
-
 func (assert *StringAssert) ArrayContains(path, expectedElement string) hammy.AssertionMessage {
 	return Bytes([]byte(assert.actual)).ArrayContains(path, []byte(expectedElement))
-}
-
-func ArrayContainsBytes(actual []byte, path string, expectedElement []byte) hammy.AssertionMessage {
-	return Bytes(actual).ArrayContains(path, expectedElement)
 }
 
 func (assert *BytesAssert) ArrayContains(path string, expectedElement []byte) hammy.AssertionMessage {

--- a/hammy/jsonassert/jsonassert.go
+++ b/hammy/jsonassert/jsonassert.go
@@ -38,25 +38,19 @@ func Reader(actual io.Reader) *ReaderAssert {
 	return &ReaderAssert{actual: actual}
 }
 
-func Equal(actual, expected string) hammy.AssertionMessage {
-	return String(actual).EqualTo(expected)
-}
+func Equal(a, e string) hammy.AssertionMessage { return String(a).EqualTo(e) }
 
 func EqualWithOptions(actual, expected string, opts ...Option) hammy.AssertionMessage {
 	return String(actual).EqualToWithOptions(expected, opts...)
 }
 
-func EqualLines(actual, expected string) hammy.AssertionMessage {
-	return String(actual).LinesEqualTo(expected)
-}
+func EqualLines(a, e string) hammy.AssertionMessage { return String(a).LinesEqualTo(e) }
 
 func EqualLinesWithOptions(actual, expected string, opts ...Option) hammy.AssertionMessage {
 	return String(actual).LinesEqualToWithOptions(expected, opts...)
 }
 
-func EqualLinesBytes(actual, expected []byte) hammy.AssertionMessage {
-	return Bytes(actual).LinesEqualTo(expected)
-}
+func EqualLinesBytes(a, e []byte) hammy.AssertionMessage { return Bytes(a).LinesEqualTo(e) }
 
 func EqualLinesBytesWithOptions(actual, expected []byte, opts ...Option) hammy.AssertionMessage {
 	return Bytes(actual).LinesEqualToWithOptions(expected, opts...)
@@ -108,13 +102,9 @@ func LinesContainSubset(actual, expected string, opts ...Option) hammy.Assertion
 	return String(actual).LinesContainSubset(expected, opts...)
 }
 
-func EqualReader(actual, expected io.Reader) hammy.AssertionMessage {
-	return Reader(actual).EqualTo(expected)
-}
+func EqualReader(a, e io.Reader) hammy.AssertionMessage { return Reader(a).EqualTo(e) }
 
-func EqualBytes(actual, expected []byte) hammy.AssertionMessage {
-	return Bytes(actual).EqualTo(expected)
-}
+func EqualBytes(a, e []byte) hammy.AssertionMessage { return Bytes(a).EqualTo(e) }
 
 func EqualBytesWithOptions(actual, expected []byte, opts ...Option) hammy.AssertionMessage {
 	return Bytes(actual).EqualToWithOptions(expected, opts...)
@@ -246,13 +236,9 @@ func ValidBytes(actual []byte) hammy.AssertionMessage {
 	return Bytes(actual).IsValid()
 }
 
-func Contains(actual, expected string) hammy.AssertionMessage {
-	return String(actual).Contains(expected)
-}
+func Contains(a, e string) hammy.AssertionMessage { return String(a).Contains(e) }
 
-func ContainsBytes(actual, expected []byte) hammy.AssertionMessage {
-	return Bytes(actual).Contains(expected)
-}
+func ContainsBytes(a, e []byte) hammy.AssertionMessage { return Bytes(a).Contains(e) }
 
 func (assert *BytesAssert) Contains(expected []byte) hammy.AssertionMessage {
 	actual := assert.actual

--- a/hammy/jsonassert/jsonassert.go
+++ b/hammy/jsonassert/jsonassert.go
@@ -14,27 +14,56 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+type StringAssert struct {
+	actual string
+}
+
+type BytesAssert struct {
+	actual []byte
+}
+
+type ReaderAssert struct {
+	actual io.Reader
+}
+
+func String(actual string) *StringAssert {
+	return &StringAssert{actual: actual}
+}
+
+func Bytes(actual []byte) *BytesAssert {
+	return &BytesAssert{actual: actual}
+}
+
+func Reader(actual io.Reader) *ReaderAssert {
+	return &ReaderAssert{actual: actual}
+}
+
 func Equal(actual, expected string) hammy.AssertionMessage {
-	return EqualBytes([]byte(actual), []byte(expected))
+	return String(actual).EqualTo(expected)
 }
 
 func EqualWithOptions(actual, expected string, opts ...Option) hammy.AssertionMessage {
-	return EqualBytesWithOptions([]byte(actual), []byte(expected), opts...)
+	return String(actual).EqualToWithOptions(expected, opts...)
 }
 
 func EqualLines(actual, expected string) hammy.AssertionMessage {
-	return EqualLinesWithOptions(actual, expected)
+	return String(actual).LinesEqualTo(expected)
 }
 
 func EqualLinesWithOptions(actual, expected string, opts ...Option) hammy.AssertionMessage {
-	return EqualLinesBytesWithOptions([]byte(actual), []byte(expected), opts...)
+	return String(actual).LinesEqualToWithOptions(expected, opts...)
 }
 
 func EqualLinesBytes(actual, expected []byte) hammy.AssertionMessage {
-	return EqualLinesBytesWithOptions(actual, expected)
+	return Bytes(actual).LinesEqualTo(expected)
 }
 
 func EqualLinesBytesWithOptions(actual, expected []byte, opts ...Option) hammy.AssertionMessage {
+	return Bytes(actual).LinesEqualToWithOptions(expected, opts...)
+}
+
+func (assert *BytesAssert) LinesEqualToWithOptions(expected []byte, opts ...Option) hammy.AssertionMessage {
+	actual := assert.actual
 	actualLines := splitJSONLines(string(actual))
 	expectedLines := splitJSONLines(string(expected))
 
@@ -72,37 +101,27 @@ func EqualLinesBytesWithOptions(actual, expected []byte, opts ...Option) hammy.A
 }
 
 func LinesContain(actual, expected string, opts ...Option) hammy.AssertionMessage {
-	return linesContain(actual, expected, opts, func(actualJSON, expectedJSON any) bool {
-		return cmp.Equal(actualJSON, expectedJSON)
-	}, "found matching JSONL line <%d>", "got no matching JSONL line")
+	return String(actual).LinesContain(expected, opts...)
 }
 
 func LinesContainSubset(actual, expected string, opts ...Option) hammy.AssertionMessage {
-	return linesContain(actual, expected, opts, func(actualJSON, expectedJSON any) bool {
-		ok, _ := containsJSON(actualJSON, expectedJSON, "$")
-		return ok
-	}, "found JSONL line <%d> containing expected subset", "got no JSONL line containing expected subset")
+	return String(actual).LinesContainSubset(expected, opts...)
 }
 
 func EqualReader(actual, expected io.Reader) hammy.AssertionMessage {
-	actualBytes, result := readJSON("actual", actual)
-	if !result.IsSuccessful {
-		return result
-	}
-
-	expectedBytes, result := readJSON("expected", expected)
-	if !result.IsSuccessful {
-		return result
-	}
-
-	return EqualBytes(actualBytes, expectedBytes)
+	return Reader(actual).EqualTo(expected)
 }
 
 func EqualBytes(actual, expected []byte) hammy.AssertionMessage {
-	return EqualBytesWithOptions(actual, expected)
+	return Bytes(actual).EqualTo(expected)
 }
 
 func EqualBytesWithOptions(actual, expected []byte, opts ...Option) hammy.AssertionMessage {
+	return Bytes(actual).EqualToWithOptions(expected, opts...)
+}
+
+func (assert *BytesAssert) EqualToWithOptions(expected []byte, opts ...Option) hammy.AssertionMessage {
+	actual := assert.actual
 	actualJSON, err := parseJSON(actual)
 	if err != nil {
 		return hammy.Assert(false, "actual JSON invalid: %v", err)
@@ -120,6 +139,80 @@ func EqualBytesWithOptions(actual, expected []byte, opts ...Option) hammy.Assert
 
 	diff := cmp.Diff(expectedJSON, actualJSON)
 	return hammy.Assert(diff == "", "JSON mismatch (-want +got):\n%s", diff)
+}
+
+func (assert *StringAssert) EqualTo(expected string, opts ...Option) hammy.AssertionMessage {
+	return assert.EqualToWithOptions(expected, opts...)
+}
+
+func (assert *StringAssert) EqualToWithOptions(expected string, opts ...Option) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).EqualToWithOptions([]byte(expected), opts...)
+}
+
+func (assert *StringAssert) LinesEqualTo(expected string) hammy.AssertionMessage {
+	return assert.LinesEqualToWithOptions(expected)
+}
+
+func (assert *StringAssert) LinesEqualToWithOptions(expected string, opts ...Option) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).LinesEqualToWithOptions([]byte(expected), opts...)
+}
+
+func (assert *StringAssert) LinesContain(expected string, opts ...Option) hammy.AssertionMessage {
+	return linesContain(assert.actual, expected, opts, func(actualJSON, expectedJSON any) bool {
+		return cmp.Equal(actualJSON, expectedJSON)
+	}, "found matching JSONL line <%d>", "got no matching JSONL line")
+}
+
+func (assert *StringAssert) LinesContainSubset(expected string, opts ...Option) hammy.AssertionMessage {
+	return linesContain(assert.actual, expected, opts, func(actualJSON, expectedJSON any) bool {
+		ok, _ := containsJSON(actualJSON, expectedJSON, "$")
+		return ok
+	}, "found JSONL line <%d> containing expected subset", "got no JSONL line containing expected subset")
+}
+
+func (assert *StringAssert) IsValid() hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).IsValid()
+}
+
+func (assert *StringAssert) Contains(expected string) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).Contains([]byte(expected))
+}
+
+func (assert *BytesAssert) EqualTo(expected []byte) hammy.AssertionMessage {
+	return assert.EqualToWithOptions(expected)
+}
+
+func (assert *BytesAssert) LinesEqualTo(expected []byte) hammy.AssertionMessage {
+	return assert.LinesEqualToWithOptions(expected)
+}
+
+func (assert *BytesAssert) IsValid() hammy.AssertionMessage {
+	if _, err := parseJSON(assert.actual); err != nil {
+		return hammy.Assert(false, "JSON invalid: %v", err)
+	}
+	return hammy.Assert(true, "got valid JSON")
+}
+
+func (assert *ReaderAssert) EqualTo(expected io.Reader) hammy.AssertionMessage {
+	actualBytes, result := readJSON("actual", assert.actual)
+	if !result.IsSuccessful {
+		return result
+	}
+
+	expectedBytes, result := readJSON("expected", expected)
+	if !result.IsSuccessful {
+		return result
+	}
+
+	return Bytes(actualBytes).EqualTo(expectedBytes)
+}
+
+func (assert *ReaderAssert) IsValid() hammy.AssertionMessage {
+	actualBytes, result := readJSON("actual", assert.actual)
+	if !result.IsSuccessful {
+		return result
+	}
+	return Bytes(actualBytes).IsValid()
 }
 
 type Option func(*compareOptions)
@@ -142,29 +235,27 @@ type compareOptions struct {
 }
 
 func Valid(actual string) hammy.AssertionMessage {
-	return ValidBytes([]byte(actual))
+	return String(actual).IsValid()
 }
 
 func ValidReader(actual io.Reader) hammy.AssertionMessage {
-	actualBytes, result := readJSON("actual", actual)
-	if !result.IsSuccessful {
-		return result
-	}
-	return ValidBytes(actualBytes)
+	return Reader(actual).IsValid()
 }
 
 func ValidBytes(actual []byte) hammy.AssertionMessage {
-	if _, err := parseJSON(actual); err != nil {
-		return hammy.Assert(false, "JSON invalid: %v", err)
-	}
-	return hammy.Assert(true, "got valid JSON")
+	return Bytes(actual).IsValid()
 }
 
 func Contains(actual, expected string) hammy.AssertionMessage {
-	return ContainsBytes([]byte(actual), []byte(expected))
+	return String(actual).Contains(expected)
 }
 
 func ContainsBytes(actual, expected []byte) hammy.AssertionMessage {
+	return Bytes(actual).Contains(expected)
+}
+
+func (assert *BytesAssert) Contains(expected []byte) hammy.AssertionMessage {
+	actual := assert.actual
 	actualJSON, err := parseJSON(actual)
 	if err != nil {
 		return hammy.Assert(false, "actual JSON invalid: %v", err)
@@ -182,7 +273,11 @@ func ContainsBytes(actual, expected []byte) hammy.AssertionMessage {
 }
 
 func PathExists(actual, path string) hammy.AssertionMessage {
-	actualJSON, err := parseJSON([]byte(actual))
+	return String(actual).PathExists(path)
+}
+
+func (assert *StringAssert) PathExists(path string) hammy.AssertionMessage {
+	actualJSON, err := parseJSON([]byte(assert.actual))
 	if err != nil {
 		return hammy.Assert(false, "actual JSON invalid: %v", err)
 	}
@@ -196,7 +291,11 @@ func PathExists(actual, path string) hammy.AssertionMessage {
 }
 
 func PathMissing(actual, path string) hammy.AssertionMessage {
-	actualJSON, err := parseJSON([]byte(actual))
+	return String(actual).PathMissing(path)
+}
+
+func (assert *StringAssert) PathMissing(path string) hammy.AssertionMessage {
+	actualJSON, err := parseJSON([]byte(assert.actual))
 	if err != nil {
 		return hammy.Assert(false, "actual JSON invalid: %v", err)
 	}
@@ -210,10 +309,19 @@ func PathMissing(actual, path string) hammy.AssertionMessage {
 }
 
 func PathEqual(actual, path, expected string) hammy.AssertionMessage {
-	return PathEqualBytes([]byte(actual), path, []byte(expected))
+	return String(actual).PathEqual(path, expected)
+}
+
+func (assert *StringAssert) PathEqual(path, expected string) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).PathEqual(path, []byte(expected))
 }
 
 func PathEqualBytes(actual []byte, path string, expected []byte) hammy.AssertionMessage {
+	return Bytes(actual).PathEqual(path, expected)
+}
+
+func (assert *BytesAssert) PathEqual(path string, expected []byte) hammy.AssertionMessage {
+	actual := assert.actual
 	actualJSON, err := parseJSON(actual)
 	if err != nil {
 		return hammy.Assert(false, "actual JSON invalid: %v", err)
@@ -237,10 +345,19 @@ func PathEqualBytes(actual []byte, path string, expected []byte) hammy.Assertion
 }
 
 func ArrayContains(actual, path, expectedElement string) hammy.AssertionMessage {
-	return ArrayContainsBytes([]byte(actual), path, []byte(expectedElement))
+	return String(actual).ArrayContains(path, expectedElement)
+}
+
+func (assert *StringAssert) ArrayContains(path, expectedElement string) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).ArrayContains(path, []byte(expectedElement))
 }
 
 func ArrayContainsBytes(actual []byte, path string, expectedElement []byte) hammy.AssertionMessage {
+	return Bytes(actual).ArrayContains(path, expectedElement)
+}
+
+func (assert *BytesAssert) ArrayContains(path string, expectedElement []byte) hammy.AssertionMessage {
+	actual := assert.actual
 	actualJSON, err := parseJSON(actual)
 	if err != nil {
 		return hammy.Assert(false, "actual JSON invalid: %v", err)

--- a/hammy/jsonassert/jsonassert_test.go
+++ b/hammy/jsonassert/jsonassert_test.go
@@ -14,7 +14,7 @@ import (
 func Test_Equal_success_compact_vs_formatted(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.Equal(`{"name":"Ada","age":37}`, `{
+	assert.Is(jsonassert.String(`{"name":"Ada","age":37}`).EqualTo(`{
 		"name": "Ada",
 		"age": 37
 	}`))
@@ -23,11 +23,11 @@ func Test_Equal_success_compact_vs_formatted(t *testing.T) {
 func Test_Equal_success_reordered_object_keys(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.Equal(`{"name":"Ada","age":37}`, `{"age":37,"name":"Ada"}`))
+	assert.Is(jsonassert.String(`{"name":"Ada","age":37}`).EqualTo(`{"age":37,"name":"Ada"}`))
 }
 
 func Test_Equal_failure_array_order_mismatch(t *testing.T) {
-	result := jsonassert.Equal(`{"values":[1,2,3]}`, `{"values":[3,2,1]}`)
+	result := jsonassert.String(`{"values":[1,2,3]}`).EqualTo(`{"values":[3,2,1]}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -38,20 +38,17 @@ func Test_Equal_failure_array_order_mismatch(t *testing.T) {
 func Test_Equal_success_numeric_spelling_equivalence(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.Equal(`{"one":1,"small":0.10}`, `{"one":1.0,"small":1e-1}`))
+	assert.Is(jsonassert.String(`{"one":1,"small":0.10}`).EqualTo(`{"one":1.0,"small":1e-1}`))
 }
 
 func Test_Equal_success_large_numeric_spelling_equivalence(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.Equal(
-		`{"id":123456789012345678901234567890}`,
-		`{"id":123456789012345678901234567890.0}`,
-	))
+	assert.Is(jsonassert.String(`{"id":123456789012345678901234567890}`).EqualTo(`{"id":123456789012345678901234567890.0}`))
 }
 
 func Test_Equal_failure_invalid_actual_json(t *testing.T) {
-	result := jsonassert.Equal(`{"name":`, `{"name":"Ada"}`)
+	result := jsonassert.String(`{"name":`).EqualTo(`{"name":"Ada"}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -60,7 +57,7 @@ func Test_Equal_failure_invalid_actual_json(t *testing.T) {
 }
 
 func Test_Equal_failure_invalid_expected_json(t *testing.T) {
-	result := jsonassert.Equal(`{"name":"Ada"}`, `{"name":`)
+	result := jsonassert.String(`{"name":"Ada"}`).EqualTo(`{"name":`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -69,7 +66,7 @@ func Test_Equal_failure_invalid_expected_json(t *testing.T) {
 }
 
 func Test_Equal_failure_multiple_actual_json_values(t *testing.T) {
-	result := jsonassert.Equal(`{"name":"Ada"} {"name":"Grace"}`, `{"name":"Ada"}`)
+	result := jsonassert.String(`{"name":"Ada"} {"name":"Grace"}`).EqualTo(`{"name":"Ada"}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -78,7 +75,7 @@ func Test_Equal_failure_multiple_actual_json_values(t *testing.T) {
 }
 
 func Test_Equal_failure_includes_diff(t *testing.T) {
-	result := jsonassert.Equal(`{"name":"Ada"}`, `{"name":"Grace"}`)
+	result := jsonassert.String(`{"name":"Ada"}`).EqualTo(`{"name":"Grace"}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -91,20 +88,17 @@ func Test_Equal_failure_includes_diff(t *testing.T) {
 func Test_EqualBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualBytes([]byte(`{"name":"Ada"}`), []byte(`{"name":"Ada"}`)))
+	assert.Is(jsonassert.Bytes([]byte(`{"name":"Ada"}`)).EqualTo([]byte(`{"name":"Ada"}`)))
 }
 
 func Test_EqualReader_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualReader(
-		strings.NewReader(`{"one":1}`),
-		strings.NewReader(`{"one":1.0}`),
-	))
+	assert.Is(jsonassert.Reader(strings.NewReader(`{"one":1}`)).EqualTo(strings.NewReader(`{"one":1.0}`)))
 }
 
 func Test_EqualReader_failure_nil_actual_reader(t *testing.T) {
-	result := jsonassert.EqualReader(nil, strings.NewReader(`{"name":"Ada"}`))
+	result := jsonassert.Reader(nil).EqualTo(strings.NewReader(`{"name":"Ada"}`))
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -113,7 +107,7 @@ func Test_EqualReader_failure_nil_actual_reader(t *testing.T) {
 }
 
 func Test_EqualReader_failure_expected_read_error(t *testing.T) {
-	result := jsonassert.EqualReader(strings.NewReader(`{"name":"Ada"}`), errorReader{})
+	result := jsonassert.Reader(strings.NewReader(`{"name":"Ada"}`)).EqualTo(errorReader{})
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -124,80 +118,53 @@ func Test_EqualReader_failure_expected_read_error(t *testing.T) {
 func Test_EqualLines_success_multiline(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualLines(
-		`{"name":"Ada","age":37}`+"\n"+`{"tags":["go","json"]}`,
-		`{"age":37.0,"name":"Ada"}`+"\n"+`{"tags":["go","json"]}`,
-	))
+	assert.Is(jsonassert.String(`{"name":"Ada","age":37}` + "\n" + `{"tags":["go","json"]}`).LinesEqualTo(`{"age":37.0,"name":"Ada"}` + "\n" + `{"tags":["go","json"]}`))
 }
 
 func Test_EqualLines_success_trailing_newline(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualLines(
-		"{\"id\":1}\n{\"id\":2}\n",
-		"{\"id\":1.0}\n{\"id\":2.0}\n",
-	))
+	assert.Is(jsonassert.String("{\"id\":1}\n{\"id\":2}\n").LinesEqualTo("{\"id\":1.0}\n{\"id\":2.0}\n"))
 }
 
 func Test_EqualLines_success_crlf(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualLines(
-		"{\"id\":1}\r\n{\"id\":2}\r\n",
-		"{\"id\":1.0}\r\n{\"id\":2.0}\r\n",
-	))
+	assert.Is(jsonassert.String("{\"id\":1}\r\n{\"id\":2}\r\n").LinesEqualTo("{\"id\":1.0}\r\n{\"id\":2.0}\r\n"))
 }
 
 func Test_EqualLines_success_empty_inputs(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualLines("", ""))
+	assert.Is(jsonassert.String("").LinesEqualTo(""))
 }
 
 func Test_EqualLinesWithOptions_success_ignore_paths_per_line(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualLinesWithOptions(
-		`{"status":"ok","meta":{"request_id":"abc"}}`+"\n"+`{"status":"ok","meta":{"request_id":"def"}}`,
-		`{"status":"ok","meta":{"request_id":"uvw"}}`+"\n"+`{"status":"ok","meta":{"request_id":"xyz"}}`,
-		jsonassert.IgnorePaths("meta.request_id"),
-	))
+	assert.Is(jsonassert.String(`{"status":"ok","meta":{"request_id":"abc"}}`+"\n"+`{"status":"ok","meta":{"request_id":"def"}}`).LinesEqualToWithOptions(`{"status":"ok","meta":{"request_id":"uvw"}}`+"\n"+`{"status":"ok","meta":{"request_id":"xyz"}}`, jsonassert.IgnorePaths("meta.request_id")))
 }
 
 func Test_EqualLinesWithOptions_success_unordered_arrays_per_line(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualLinesWithOptions(
-		`{"tags":["go","test"]}`+"\n"+`{"tags":["json","assert"]}`,
-		`{"tags":["test","go"]}`+"\n"+`{"tags":["assert","json"]}`,
-		jsonassert.UnorderedArraysAt("tags"),
-	))
+	assert.Is(jsonassert.String(`{"tags":["go","test"]}`+"\n"+`{"tags":["json","assert"]}`).LinesEqualToWithOptions(`{"tags":["test","go"]}`+"\n"+`{"tags":["assert","json"]}`, jsonassert.UnorderedArraysAt("tags")))
 }
 
 func Test_EqualLinesBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualLinesBytes(
-		[]byte(`{"id":1}`+"\n"+`{"id":2}`),
-		[]byte(`{"id":1.0}`+"\n"+`{"id":2.0}`),
-	))
+	assert.Is(jsonassert.Bytes([]byte(`{"id":1}` + "\n" + `{"id":2}`)).LinesEqualTo([]byte(`{"id":1.0}` + "\n" + `{"id":2.0}`)))
 }
 
 func Test_EqualLinesBytesWithOptions_success_ignore_paths_per_line(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualLinesBytesWithOptions(
-		[]byte(`{"status":"ok","meta":{"request_id":"abc"}}`+"\n"+`{"status":"ok","meta":{"request_id":"def"}}`),
-		[]byte(`{"status":"ok","meta":{"request_id":"uvw"}}`+"\n"+`{"status":"ok","meta":{"request_id":"xyz"}}`),
-		jsonassert.IgnorePaths("meta.request_id"),
-	))
+	assert.Is(jsonassert.Bytes([]byte(`{"status":"ok","meta":{"request_id":"abc"}}`+"\n"+`{"status":"ok","meta":{"request_id":"def"}}`)).LinesEqualToWithOptions([]byte(`{"status":"ok","meta":{"request_id":"uvw"}}`+"\n"+`{"status":"ok","meta":{"request_id":"xyz"}}`), jsonassert.IgnorePaths("meta.request_id")))
 }
 
 func Test_EqualLines_failure_reports_line_index(t *testing.T) {
-	result := jsonassert.EqualLines(
-		`{"id":1,"name":"Ada"}`+"\n"+`{"id":2,"name":"Grace"}`,
-		`{"id":1,"name":"Ada"}`+"\n"+`{"id":2,"name":"Katherine"}`,
-	)
+	result := jsonassert.String(`{"id":1,"name":"Ada"}` + "\n" + `{"id":2,"name":"Grace"}`).LinesEqualTo(`{"id":1,"name":"Ada"}` + "\n" + `{"id":2,"name":"Katherine"}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -208,10 +175,7 @@ func Test_EqualLines_failure_reports_line_index(t *testing.T) {
 }
 
 func Test_EqualLinesBytes_failure_reports_line_index(t *testing.T) {
-	result := jsonassert.EqualLinesBytes(
-		[]byte(`{"id":1}`+"\n"+`{"id":2}`),
-		[]byte(`{"id":1}`+"\n"+`{"id":3}`),
-	)
+	result := jsonassert.Bytes([]byte(`{"id":1}` + "\n" + `{"id":2}`)).LinesEqualTo([]byte(`{"id":1}` + "\n" + `{"id":3}`))
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -220,10 +184,7 @@ func Test_EqualLinesBytes_failure_reports_line_index(t *testing.T) {
 }
 
 func Test_EqualLines_failure_invalid_actual_json_reports_line_index(t *testing.T) {
-	result := jsonassert.EqualLines(
-		`{"id":1}`+"\n"+`{"id":`,
-		`{"id":1}`+"\n"+`{"id":2}`,
-	)
+	result := jsonassert.String(`{"id":1}` + "\n" + `{"id":`).LinesEqualTo(`{"id":1}` + "\n" + `{"id":2}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -232,10 +193,7 @@ func Test_EqualLines_failure_invalid_actual_json_reports_line_index(t *testing.T
 }
 
 func Test_EqualLines_failure_invalid_expected_json_reports_line_index(t *testing.T) {
-	result := jsonassert.EqualLines(
-		`{"id":1}`+"\n"+`{"id":2}`,
-		`{"id":1}`+"\n"+`{"id":`,
-	)
+	result := jsonassert.String(`{"id":1}` + "\n" + `{"id":2}`).LinesEqualTo(`{"id":1}` + "\n" + `{"id":`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -244,10 +202,7 @@ func Test_EqualLines_failure_invalid_expected_json_reports_line_index(t *testing
 }
 
 func Test_EqualLines_failure_blank_middle_line_invalid_json(t *testing.T) {
-	result := jsonassert.EqualLines(
-		`{"id":1}`+"\n\n"+`{"id":2}`,
-		`{"id":1}`+"\n\n"+`{"id":2}`,
-	)
+	result := jsonassert.String(`{"id":1}` + "\n\n" + `{"id":2}`).LinesEqualTo(`{"id":1}` + "\n\n" + `{"id":2}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -256,10 +211,7 @@ func Test_EqualLines_failure_blank_middle_line_invalid_json(t *testing.T) {
 }
 
 func Test_EqualLines_failure_line_count_mismatch_reports_index(t *testing.T) {
-	result := jsonassert.EqualLines(
-		`{"id":1}`,
-		`{"id":1}`+"\n"+`{"id":2}`,
-	)
+	result := jsonassert.String(`{"id":1}`).LinesEqualTo(`{"id":1}` + "\n" + `{"id":2}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -268,11 +220,7 @@ func Test_EqualLines_failure_line_count_mismatch_reports_index(t *testing.T) {
 }
 
 func Test_EqualLinesWithOptions_failure_invalid_option_reports_line_index(t *testing.T) {
-	result := jsonassert.EqualLinesWithOptions(
-		`{"status":"ok"}`,
-		`{"status":"ok"}`,
-		jsonassert.IgnorePaths("meta."),
-	)
+	result := jsonassert.String(`{"status":"ok"}`).LinesEqualToWithOptions(`{"status":"ok"}`, jsonassert.IgnorePaths("meta."))
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -283,27 +231,17 @@ func Test_EqualLinesWithOptions_failure_invalid_option_reports_line_index(t *tes
 func Test_LinesContain_success_full_record(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.LinesContain(
-		`{"id":1,"name":"Ada"}`+"\n"+`{"id":2,"score":1.0}`,
-		`{"score":1,"id":2}`,
-	))
+	assert.Is(jsonassert.String(`{"id":1,"name":"Ada"}` + "\n" + `{"id":2,"score":1.0}`).LinesContain(`{"score":1,"id":2}`))
 }
 
 func Test_LinesContain_success_ignore_paths(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.LinesContain(
-		`{"status":"ok","meta":{"request_id":"abc"}}`+"\n"+`{"status":"done","meta":{"request_id":"def"}}`,
-		`{"status":"done","meta":{"request_id":"xyz"}}`,
-		jsonassert.IgnorePaths("meta.request_id"),
-	))
+	assert.Is(jsonassert.String(`{"status":"ok","meta":{"request_id":"abc"}}`+"\n"+`{"status":"done","meta":{"request_id":"def"}}`).LinesContain(`{"status":"done","meta":{"request_id":"xyz"}}`, jsonassert.IgnorePaths("meta.request_id")))
 }
 
 func Test_LinesContain_failure_no_match(t *testing.T) {
-	result := jsonassert.LinesContain(
-		`{"id":1}`+"\n"+`{"id":2}`,
-		`{"id":3}`,
-	)
+	result := jsonassert.String(`{"id":1}` + "\n" + `{"id":2}`).LinesContain(`{"id":3}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -312,7 +250,7 @@ func Test_LinesContain_failure_no_match(t *testing.T) {
 }
 
 func Test_LinesContain_failure_invalid_expected_json(t *testing.T) {
-	result := jsonassert.LinesContain(`{"id":1}`, `{"id":`)
+	result := jsonassert.String(`{"id":1}`).LinesContain(`{"id":`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -321,10 +259,7 @@ func Test_LinesContain_failure_invalid_expected_json(t *testing.T) {
 }
 
 func Test_LinesContain_failure_invalid_actual_line(t *testing.T) {
-	result := jsonassert.LinesContain(
-		`{"id":1}`+"\n"+`{"id":`,
-		`{"id":2}`,
-	)
+	result := jsonassert.String(`{"id":1}` + "\n" + `{"id":`).LinesContain(`{"id":2}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -333,11 +268,7 @@ func Test_LinesContain_failure_invalid_actual_line(t *testing.T) {
 }
 
 func Test_LinesContain_failure_invalid_option_reports_line_index(t *testing.T) {
-	result := jsonassert.LinesContain(
-		`{"status":"ok"}`,
-		`{"status":"ok"}`,
-		jsonassert.IgnorePaths("meta."),
-	)
+	result := jsonassert.String(`{"status":"ok"}`).LinesContain(`{"status":"ok"}`, jsonassert.IgnorePaths("meta."))
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -348,27 +279,17 @@ func Test_LinesContain_failure_invalid_option_reports_line_index(t *testing.T) {
 func Test_LinesContainSubset_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.LinesContainSubset(
-		`{"status":"ok","meta":{"request_id":"abc","page":1}}`+"\n"+`{"status":"done"}`,
-		`{"meta":{"page":1.0}}`,
-	))
+	assert.Is(jsonassert.String(`{"status":"ok","meta":{"request_id":"abc","page":1}}` + "\n" + `{"status":"done"}`).LinesContainSubset(`{"meta":{"page":1.0}}`))
 }
 
 func Test_LinesContainSubset_success_ignore_paths(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.LinesContainSubset(
-		`{"status":"ok","meta":{"request_id":"abc","page":1}}`,
-		`{"meta":{"request_id":"xyz","page":1.0}}`,
-		jsonassert.IgnorePaths("meta.request_id"),
-	))
+	assert.Is(jsonassert.String(`{"status":"ok","meta":{"request_id":"abc","page":1}}`).LinesContainSubset(`{"meta":{"request_id":"xyz","page":1.0}}`, jsonassert.IgnorePaths("meta.request_id")))
 }
 
 func Test_LinesContainSubset_failure_no_match(t *testing.T) {
-	result := jsonassert.LinesContainSubset(
-		`{"status":"ok"}`+"\n"+`{"status":"done"}`,
-		`{"meta":{"page":1}}`,
-	)
+	result := jsonassert.String(`{"status":"ok"}` + "\n" + `{"status":"done"}`).LinesContainSubset(`{"meta":{"page":1}}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -379,11 +300,11 @@ func Test_LinesContainSubset_failure_no_match(t *testing.T) {
 func Test_Valid_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.Valid(`{"name":"Ada"}`))
+	assert.Is(jsonassert.String(`{"name":"Ada"}`).IsValid())
 }
 
 func Test_Valid_failure(t *testing.T) {
-	result := jsonassert.Valid(`{"name":`)
+	result := jsonassert.String(`{"name":`).IsValid()
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -394,17 +315,17 @@ func Test_Valid_failure(t *testing.T) {
 func Test_ValidBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.ValidBytes([]byte(`{"name":"Ada"}`)))
+	assert.Is(jsonassert.Bytes([]byte(`{"name":"Ada"}`)).IsValid())
 }
 
 func Test_ValidReader_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.ValidReader(strings.NewReader(`{"name":"Ada"}`)))
+	assert.Is(jsonassert.Reader(strings.NewReader(`{"name":"Ada"}`)).IsValid())
 }
 
 func Test_ValidReader_failure_read_error(t *testing.T) {
-	result := jsonassert.ValidReader(errorReader{})
+	result := jsonassert.Reader(errorReader{}).IsValid()
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -415,14 +336,11 @@ func Test_ValidReader_failure_read_error(t *testing.T) {
 func Test_Contains_success_object_subset(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.Contains(
-		`{"status":"ok","meta":{"request_id":"abc","page":1}}`,
-		`{"status":"ok","meta":{"page":1.0}}`,
-	))
+	assert.Is(jsonassert.String(`{"status":"ok","meta":{"request_id":"abc","page":1}}`).Contains(`{"status":"ok","meta":{"page":1.0}}`))
 }
 
 func Test_Contains_failure_missing_field(t *testing.T) {
-	result := jsonassert.Contains(`{"status":"ok"}`, `{"meta":{"page":1}}`)
+	result := jsonassert.String(`{"status":"ok"}`).Contains(`{"meta":{"page":1}}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -431,7 +349,7 @@ func Test_Contains_failure_missing_field(t *testing.T) {
 }
 
 func Test_Contains_failure_mismatched_value(t *testing.T) {
-	result := jsonassert.Contains(`{"status":"ok"}`, `{"status":"failed"}`)
+	result := jsonassert.String(`{"status":"ok"}`).Contains(`{"status":"failed"}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -440,7 +358,7 @@ func Test_Contains_failure_mismatched_value(t *testing.T) {
 }
 
 func Test_Contains_failure_array_order_sensitive(t *testing.T) {
-	result := jsonassert.Contains(`{"values":[1,2,3]}`, `{"values":[3,2,1]}`)
+	result := jsonassert.String(`{"values":[1,2,3]}`).Contains(`{"values":[3,2,1]}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -451,23 +369,23 @@ func Test_Contains_failure_array_order_sensitive(t *testing.T) {
 func Test_ContainsBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.ContainsBytes([]byte(`{"status":"ok","extra":true}`), []byte(`{"status":"ok"}`)))
+	assert.Is(jsonassert.Bytes([]byte(`{"status":"ok","extra":true}`)).Contains([]byte(`{"status":"ok"}`)))
 }
 
 func Test_PathExists_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.PathExists(`{"user":{"name":"Ada"}}`, "user.name"))
+	assert.Is(jsonassert.String(`{"user":{"name":"Ada"}}`).PathExists("user.name"))
 }
 
 func Test_PathExists_success_array_index(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.PathExists(`{"items":[{"id":1}]}`, "items[0].id"))
+	assert.Is(jsonassert.String(`{"items":[{"id":1}]}`).PathExists("items[0].id"))
 }
 
 func Test_PathExists_failure_missing(t *testing.T) {
-	result := jsonassert.PathExists(`{"user":{"name":"Ada"}}`, "user.email")
+	result := jsonassert.String(`{"user":{"name":"Ada"}}`).PathExists("user.email")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -476,7 +394,7 @@ func Test_PathExists_failure_missing(t *testing.T) {
 }
 
 func Test_PathExists_failure_invalid_path(t *testing.T) {
-	result := jsonassert.PathExists(`{"user":{"name":"Ada"}}`, "user.")
+	result := jsonassert.String(`{"user":{"name":"Ada"}}`).PathExists("user.")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -487,11 +405,11 @@ func Test_PathExists_failure_invalid_path(t *testing.T) {
 func Test_PathMissing_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.PathMissing(`{"user":{"name":"Ada"}}`, "user.email"))
+	assert.Is(jsonassert.String(`{"user":{"name":"Ada"}}`).PathMissing("user.email"))
 }
 
 func Test_PathMissing_failure_exists(t *testing.T) {
-	result := jsonassert.PathMissing(`{"user":{"name":"Ada"}}`, "user.name")
+	result := jsonassert.String(`{"user":{"name":"Ada"}}`).PathMissing("user.name")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -502,11 +420,11 @@ func Test_PathMissing_failure_exists(t *testing.T) {
 func Test_PathEqual_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.PathEqual(`{"user":{"name":"Ada","age":37}}`, "user.age", `37.0`))
+	assert.Is(jsonassert.String(`{"user":{"name":"Ada","age":37}}`).PathEqual("user.age", `37.0`))
 }
 
 func Test_PathEqual_failure_mismatch(t *testing.T) {
-	result := jsonassert.PathEqual(`{"user":{"name":"Ada"}}`, "user.name", `"Grace"`)
+	result := jsonassert.String(`{"user":{"name":"Ada"}}`).PathEqual("user.name", `"Grace"`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -519,17 +437,17 @@ func Test_PathEqual_failure_mismatch(t *testing.T) {
 func Test_PathEqualBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.PathEqualBytes([]byte(`{"user":{"name":"Ada"}}`), "user.name", []byte(`"Ada"`)))
+	assert.Is(jsonassert.Bytes([]byte(`{"user":{"name":"Ada"}}`)).PathEqual("user.name", []byte(`"Ada"`)))
 }
 
 func Test_ArrayContains_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.ArrayContains(`{"items":[{"id":1},{"id":2}]}`, "items", `{"id":2.0}`))
+	assert.Is(jsonassert.String(`{"items":[{"id":1},{"id":2}]}`).ArrayContains("items", `{"id":2.0}`))
 }
 
 func Test_ArrayContains_failure_missing_element(t *testing.T) {
-	result := jsonassert.ArrayContains(`{"items":[{"id":1}]}`, "items", `{"id":2}`)
+	result := jsonassert.String(`{"items":[{"id":1}]}`).ArrayContains("items", `{"id":2}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -538,7 +456,7 @@ func Test_ArrayContains_failure_missing_element(t *testing.T) {
 }
 
 func Test_ArrayContains_failure_non_array_path(t *testing.T) {
-	result := jsonassert.ArrayContains(`{"items":{"id":1}}`, "items", `{"id":1}`)
+	result := jsonassert.String(`{"items":{"id":1}}`).ArrayContains("items", `{"id":1}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -549,31 +467,23 @@ func Test_ArrayContains_failure_non_array_path(t *testing.T) {
 func Test_ArrayContainsBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.ArrayContainsBytes([]byte(`{"items":[1,2]}`), "items", []byte(`2.0`)))
+	assert.Is(jsonassert.Bytes([]byte(`{"items":[1,2]}`)).ArrayContains("items", []byte(`2.0`)))
 }
 
 func Test_EqualWithOptions_success_ignore_paths(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualWithOptions(
-		`{"status":"ok","meta":{"request_id":"abc"}}`,
-		`{"status":"ok","meta":{"request_id":"xyz"}}`,
-		jsonassert.IgnorePaths("meta.request_id"),
-	))
+	assert.Is(jsonassert.String(`{"status":"ok","meta":{"request_id":"abc"}}`).EqualToWithOptions(`{"status":"ok","meta":{"request_id":"xyz"}}`, jsonassert.IgnorePaths("meta.request_id")))
 }
 
 func Test_EqualWithOptions_success_ignore_array_item_path(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualWithOptions(
-		`{"items":[{"id":1,"etag":"a"}]}`,
-		`{"items":[{"id":1,"etag":"b"}]}`,
-		jsonassert.IgnorePaths("items[0].etag"),
-	))
+	assert.Is(jsonassert.String(`{"items":[{"id":1,"etag":"a"}]}`).EqualToWithOptions(`{"items":[{"id":1,"etag":"b"}]}`, jsonassert.IgnorePaths("items[0].etag")))
 }
 
 func Test_EqualWithOptions_failure_invalid_ignore_path(t *testing.T) {
-	result := jsonassert.EqualWithOptions(`{"status":"ok"}`, `{"status":"ok"}`, jsonassert.IgnorePaths("meta."))
+	result := jsonassert.String(`{"status":"ok"}`).EqualToWithOptions(`{"status":"ok"}`, jsonassert.IgnorePaths("meta."))
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -584,29 +494,17 @@ func Test_EqualWithOptions_failure_invalid_ignore_path(t *testing.T) {
 func Test_EqualWithOptions_success_unordered_array(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualWithOptions(
-		`{"tags":["go","test","json"]}`,
-		`{"tags":["json","go","test"]}`,
-		jsonassert.UnorderedArraysAt("tags"),
-	))
+	assert.Is(jsonassert.String(`{"tags":["go","test","json"]}`).EqualToWithOptions(`{"tags":["json","go","test"]}`, jsonassert.UnorderedArraysAt("tags")))
 }
 
 func Test_EqualWithOptions_success_unordered_array_of_objects(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualWithOptions(
-		`{"items":[{"id":2},{"id":1}]}`,
-		`{"items":[{"id":1.0},{"id":2.0}]}`,
-		jsonassert.UnorderedArraysAt("items"),
-	))
+	assert.Is(jsonassert.String(`{"items":[{"id":2},{"id":1}]}`).EqualToWithOptions(`{"items":[{"id":1.0},{"id":2.0}]}`, jsonassert.UnorderedArraysAt("items")))
 }
 
 func Test_EqualWithOptions_failure_unordered_array_non_array_path(t *testing.T) {
-	result := jsonassert.EqualWithOptions(
-		`{"items":{"id":1}}`,
-		`{"items":{"id":1}}`,
-		jsonassert.UnorderedArraysAt("items"),
-	)
+	result := jsonassert.String(`{"items":{"id":1}}`).EqualToWithOptions(`{"items":{"id":1}}`, jsonassert.UnorderedArraysAt("items"))
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -615,10 +513,7 @@ func Test_EqualWithOptions_failure_unordered_array_non_array_path(t *testing.T) 
 }
 
 func Test_EqualWithOptions_failure_without_ignore_paths(t *testing.T) {
-	result := jsonassert.EqualWithOptions(
-		`{"status":"ok","meta":{"request_id":"abc"}}`,
-		`{"status":"ok","meta":{"request_id":"xyz"}}`,
-	)
+	result := jsonassert.String(`{"status":"ok","meta":{"request_id":"abc"}}`).EqualToWithOptions(`{"status":"ok","meta":{"request_id":"xyz"}}`)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -629,11 +524,7 @@ func Test_EqualWithOptions_failure_without_ignore_paths(t *testing.T) {
 func Test_EqualBytesWithOptions_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(jsonassert.EqualBytesWithOptions(
-		[]byte(`{"tags":["go","test"]}`),
-		[]byte(`{"tags":["test","go"]}`),
-		jsonassert.UnorderedArraysAt("tags"),
-	))
+	assert.Is(jsonassert.Bytes([]byte(`{"tags":["go","test"]}`)).EqualToWithOptions([]byte(`{"tags":["test","go"]}`), jsonassert.UnorderedArraysAt("tags")))
 }
 
 type errorReader struct{}


### PR DESCRIPTION
### Motivation

- Provide typed assertion wrappers so JSON assertions can be invoked via a constructor/receiver API (e.g. `jsonassert.String(actual).EqualTo(expected)`) for clearer chaining and consistency with other hammy packages. 
- Preserve existing semantic behavior and internal helpers while making the public package-level functions delegate to the new receiver methods.

### Description

- Add wrapper structs `StringAssert`, `BytesAssert`, and `ReaderAssert` and constructors `String`, `Bytes`, and `Reader` in `hammy/jsonassert/jsonassert.go` to hold the actual value. 
- Implement receiver methods such as `(*StringAssert) EqualTo`, `(*StringAssert) LinesEqualToWithOptions`, `(*BytesAssert) EqualToWithOptions`, `(*ReaderAssert) EqualTo`, plus `IsValid`, `Contains`, `PathExists`, `PathMissing`, `PathEqual`, and array helpers, and delegate the original package-level functions to these methods. 
- Keep internal helper functions like `readJSON`, `linesContain`, `applyOptions`, `deleteJSONPath`, `sortJSONArrayAtPath`, `containsJSON`, path parsing, and number normalization unexported and unchanged as implementation details. 
- Update tests and examples to use the constructor/receiver API and adjust README snippets to show `jsonassert.String(...)`, `jsonassert.Bytes(...)`, and `jsonassert.Reader(...)` usages.

### Testing

- Ran `go test ./hammy/jsonassert` and the package tests passed successfully. 
- Ran the full test suite with `go test ./...` and all packages (including updated examples/tests) passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3938c94dd4832dadfb7f51c75565d6)