### PR TITLE
Refactor yamlassert to fluent `String`/`Bytes`/`Reader` assertion types and update examples/tests

### DIFF
--- a/hammy/README.md
+++ b/hammy/README.md
@@ -68,9 +68,9 @@ Use `yamlassert` for semantic YAML equality, path checks, and multi-document str
 ```go
 import ya "github.com/gogunit/gunit/hammy/yamlassert"
 
-assert.Is(ya.Equal(actualYAML, expectedYAML))
-assert.Is(ya.PathEqual(actualYAML, "user.name", "Ada\n"))
-assert.Is(ya.DocumentCount(actualYAML, 2))
+assert.Is(ya.String(actualYAML).EqualTo(expectedYAML))
+assert.Is(ya.String(actualYAML).PathEqual("user.name", "Ada\n"))
+assert.Is(ya.String(actualYAML).DocumentCount(2))
 ```
 
 ## Generic Matcher Core
@@ -159,30 +159,32 @@ func Test_payload_has_expected_type(t *testing.T) {
 
 ## YAML (`hammy/yamlassert`)
 
-* [x] ArrayContains
-* [x] ArrayContainsBytes
-* [x] Contains
-* [x] ContainsBytes
-* [x] DocumentContains
-* [x] DocumentContainsBytes
-* [x] DocumentCount
-* [x] DocumentCountBytes
-* [x] DocumentEqual
-* [x] DocumentEqualBytes
-* [x] Equal
-* [x] EqualBytes
-* [x] EqualBytesWithOptions
-* [x] EqualReader
-* [x] EqualWithOptions
+* [x] Bytes
+* [x] Bytes.ArrayContains
+* [x] Bytes.Contains
+* [x] Bytes.DocumentContains
+* [x] Bytes.DocumentCount
+* [x] Bytes.DocumentEqual
+* [x] Bytes.EqualTo
+* [x] Bytes.EqualToWithOptions
+* [x] Reader
+* [x] Reader.EqualTo
+* [x] Reader.IsValid
+* [x] String
+* [x] String.ArrayContains
+* [x] String.Contains
+* [x] String.DocumentContains
+* [x] String.DocumentCount
+* [x] String.DocumentEqual
+* [x] String.EqualTo
+* [x] String.EqualToWithOptions
 * [x] IgnorePaths
-* [x] PathEqual
-* [x] PathEqualBytes
-* [x] PathExists
-* [x] PathMissing
+* [x] String.PathEqual
+* [x] String.PathExists
+* [x] String.PathMissing
 * [x] UnorderedArraysAt
-* [x] Valid
-* [x] ValidBytes
-* [x] ValidReader
+* [x] String.IsValid
+* [x] Bytes.IsValid
 
 ## Number
 

--- a/hammy/yamlassert/example_test.go
+++ b/hammy/yamlassert/example_test.go
@@ -8,139 +8,139 @@ import (
 	"github.com/gogunit/gunit/hammy/yamlassert"
 )
 
-func ExampleEqual() {
+func ExampleStringAssert_EqualTo() {
 	actual := "name: Ada\nage: 37\n"
 	expected := "age: 37.0\nname: Ada\n"
 
-	printExample(yamlassert.Equal(actual, expected))
+	printExample(yamlassert.String(actual).EqualTo(expected))
 	// Output:
 	// message="YAML mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExampleEqualWithOptions() {
+func ExampleStringAssert_EqualToWithOptions() {
 	actual := "status: ok\nmeta:\n  request_id: abc\n"
 	expected := "status: ok\nmeta:\n  request_id: xyz\n"
 
-	printExample(yamlassert.EqualWithOptions(actual, expected, yamlassert.IgnorePaths("meta.request_id")))
+	printExample(yamlassert.String(actual).EqualTo(expected, yamlassert.IgnorePaths("meta.request_id")))
 	// Output:
 	// message="YAML mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExampleEqualBytes() {
-	printExample(yamlassert.EqualBytes([]byte("one: 1\n"), []byte("one: 1.0\n")))
+func ExampleBytesAssert_EqualTo() {
+	printExample(yamlassert.Bytes([]byte("one: 1\n")).EqualTo([]byte("one: 1.0\n")))
 	// Output:
 	// message="YAML mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExampleEqualBytesWithOptions() {
+func ExampleBytesAssert_EqualToWithOptions() {
 	actual := []byte("tags: [go, test]\n")
 	expected := []byte("tags: [test, go]\n")
 
-	printExample(yamlassert.EqualBytesWithOptions(actual, expected, yamlassert.UnorderedArraysAt("tags")))
+	printExample(yamlassert.Bytes(actual).EqualTo(expected, yamlassert.UnorderedArraysAt("tags")))
 	// Output:
 	// message="YAML mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExampleEqualReader() {
+func ExampleReaderAssert_EqualTo() {
 	actual := strings.NewReader("one: 1\n")
 	expected := strings.NewReader("one: 1.0\n")
 
-	printExample(yamlassert.EqualReader(actual, expected))
+	printExample(yamlassert.Reader(actual).EqualTo(expected))
 	// Output:
 	// message="YAML mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExampleValid() {
-	printExample(yamlassert.Valid("name: Ada\n"))
+func ExampleStringAssert_IsValid() {
+	printExample(yamlassert.String("name: Ada\n").IsValid())
 	// Output:
 	// message="got valid YAML"
 	// success=true
 }
 
-func ExampleValidBytes() {
-	printExample(yamlassert.ValidBytes([]byte("name: Ada\n")))
+func ExampleBytesAssert_IsValid() {
+	printExample(yamlassert.Bytes([]byte("name: Ada\n")).IsValid())
 	// Output:
 	// message="got valid YAML"
 	// success=true
 }
 
-func ExampleValidReader() {
-	printExample(yamlassert.ValidReader(strings.NewReader("name: Ada\n")))
+func ExampleReaderAssert_IsValid() {
+	printExample(yamlassert.Reader(strings.NewReader("name: Ada\n")).IsValid())
 	// Output:
 	// message="got valid YAML"
 	// success=true
 }
 
-func ExampleContains() {
+func ExampleStringAssert_Contains() {
 	actual := "status: ok\nmeta:\n  page: 1\n  request_id: abc\n"
 	expected := "meta:\n  page: 1.0\n"
 
-	printExample(yamlassert.Contains(actual, expected))
+	printExample(yamlassert.String(actual).Contains(expected))
 	// Output:
 	// message="YAML contained expected subset"
 	// success=true
 }
 
-func ExampleContainsBytes() {
+func ExampleBytesAssert_Contains() {
 	actual := []byte("status: ok\nextra: true\n")
 	expected := []byte("status: ok\n")
 
-	printExample(yamlassert.ContainsBytes(actual, expected))
+	printExample(yamlassert.Bytes(actual).Contains(expected))
 	// Output:
 	// message="YAML contained expected subset"
 	// success=true
 }
 
-func ExamplePathExists() {
-	printExample(yamlassert.PathExists("user:\n  name: Ada\n", "user.name"))
+func ExampleStringAssert_PathExists() {
+	printExample(yamlassert.String("user:\n  name: Ada\n").PathExists("user.name"))
 	// Output:
 	// message="YAML path <user.name> exists"
 	// success=true
 }
 
-func ExamplePathMissing() {
-	printExample(yamlassert.PathMissing("user:\n  name: Ada\n", "user.email"))
+func ExampleStringAssert_PathMissing() {
+	printExample(yamlassert.String("user:\n  name: Ada\n").PathMissing("user.email"))
 	// Output:
 	// message="YAML path <user.email> missing"
 	// success=true
 }
 
-func ExamplePathEqual() {
-	printExample(yamlassert.PathEqual("user:\n  age: 37\n", "user.age", "37.0\n"))
+func ExampleStringAssert_PathEqual() {
+	printExample(yamlassert.String("user:\n  age: 37\n").PathEqual("user.age", "37.0\n"))
 	// Output:
 	// message="YAML path <user.age> mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExamplePathEqualBytes() {
+func ExampleBytesAssert_PathEqual() {
 	actual := []byte("user:\n  name: Ada\n")
 	expected := []byte("Ada\n")
 
-	printExample(yamlassert.PathEqualBytes(actual, "user.name", expected))
+	printExample(yamlassert.Bytes(actual).PathEqual("user.name", expected))
 	// Output:
 	// message="YAML path <user.name> mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExampleArrayContains() {
+func ExampleStringAssert_ArrayContains() {
 	actual := "items:\n  - id: 1\n  - id: 2\n"
 
-	printExample(yamlassert.ArrayContains(actual, "items", "id: 2.0\n"))
+	printExample(yamlassert.String(actual).ArrayContains("items", "id: 2.0\n"))
 	// Output:
 	// message="found matching element at YAML path <items> index <1>"
 	// success=true
 }
 
-func ExampleArrayContainsBytes() {
+func ExampleBytesAssert_ArrayContains() {
 	actual := []byte("items: [1, 2]\n")
 	expected := []byte("2.0\n")
 
-	printExample(yamlassert.ArrayContainsBytes(actual, "items", expected))
+	printExample(yamlassert.Bytes(actual).ArrayContains("items", expected))
 	// Output:
 	// message="found matching element at YAML path <items> index <1>"
 	// success=true
@@ -150,7 +150,7 @@ func ExampleIgnorePaths() {
 	actual := "status: ok\nmeta:\n  request_id: abc\n"
 	expected := "status: ok\nmeta:\n  request_id: xyz\n"
 
-	printExample(yamlassert.EqualWithOptions(actual, expected, yamlassert.IgnorePaths("meta.request_id")))
+	printExample(yamlassert.String(actual).EqualTo(expected, yamlassert.IgnorePaths("meta.request_id")))
 	// Output:
 	// message="YAML mismatch (-want +got):\n"
 	// success=true
@@ -160,52 +160,52 @@ func ExampleUnorderedArraysAt() {
 	actual := "tags: [go, test, yaml]\n"
 	expected := "tags: [yaml, go, test]\n"
 
-	printExample(yamlassert.EqualWithOptions(actual, expected, yamlassert.UnorderedArraysAt("tags")))
+	printExample(yamlassert.String(actual).EqualTo(expected, yamlassert.UnorderedArraysAt("tags")))
 	// Output:
 	// message="YAML mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExampleDocumentCount() {
-	printExample(yamlassert.DocumentCount("---\nname: Ada\n---\nname: Grace\n", 2))
+func ExampleStringAssert_DocumentCount() {
+	printExample(yamlassert.String("---\nname: Ada\n---\nname: Grace\n").DocumentCount(2))
 	// Output:
 	// message="got YAML document count <2>, wanted <2>"
 	// success=true
 }
 
-func ExampleDocumentCountBytes() {
-	printExample(yamlassert.DocumentCountBytes([]byte("---\nname: Ada\n---\nname: Grace\n"), 2))
+func ExampleBytesAssert_DocumentCount() {
+	printExample(yamlassert.Bytes([]byte("---\nname: Ada\n---\nname: Grace\n")).DocumentCount(2))
 	// Output:
 	// message="got YAML document count <2>, wanted <2>"
 	// success=true
 }
 
-func ExampleDocumentEqual() {
-	printExample(yamlassert.DocumentEqual("---\nname: Ada\n---\nname: Grace\n", 1, "name: Grace\n"))
+func ExampleStringAssert_DocumentEqual() {
+	printExample(yamlassert.String("---\nname: Ada\n---\nname: Grace\n").DocumentEqual(1, "name: Grace\n"))
 	// Output:
 	// message="YAML document <1> mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExampleDocumentEqualBytes() {
-	printExample(yamlassert.DocumentEqualBytes([]byte("---\nname: Ada\n"), 0, []byte("name: Ada\n")))
+func ExampleBytesAssert_DocumentEqual() {
+	printExample(yamlassert.Bytes([]byte("---\nname: Ada\n")).DocumentEqual(0, []byte("name: Ada\n")))
 	// Output:
 	// message="YAML document <0> mismatch (-want +got):\n"
 	// success=true
 }
 
-func ExampleDocumentContains() {
+func ExampleStringAssert_DocumentContains() {
 	actual := "---\nstatus: ok\nmeta:\n  page: 1\n"
 	expected := "meta:\n  page: 1.0\n"
 
-	printExample(yamlassert.DocumentContains(actual, 0, expected))
+	printExample(yamlassert.String(actual).DocumentContains(0, expected))
 	// Output:
 	// message="YAML document <0> contained expected subset"
 	// success=true
 }
 
-func ExampleDocumentContainsBytes() {
-	printExample(yamlassert.DocumentContainsBytes([]byte("---\nstatus: ok\n"), 0, []byte("status: ok\n")))
+func ExampleBytesAssert_DocumentContains() {
+	printExample(yamlassert.Bytes([]byte("---\nstatus: ok\n")).DocumentContains(0, []byte("status: ok\n")))
 	// Output:
 	// message="YAML document <0> contained expected subset"
 	// success=true

--- a/hammy/yamlassert/yamlassert.go
+++ b/hammy/yamlassert/yamlassert.go
@@ -14,16 +14,40 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func Equal(actual, expected string) hammy.AssertionMessage {
-	return EqualBytes([]byte(actual), []byte(expected))
+type StringAssert struct {
+	actual string
 }
 
-func EqualWithOptions(actual, expected string, opts ...Option) hammy.AssertionMessage {
-	return EqualBytesWithOptions([]byte(actual), []byte(expected), opts...)
+type BytesAssert struct {
+	actual []byte
 }
 
-func EqualReader(actual, expected io.Reader) hammy.AssertionMessage {
-	actualBytes, result := readYAML("actual", actual)
+type ReaderAssert struct {
+	actual io.Reader
+}
+
+func String(actual string) *StringAssert {
+	return &StringAssert{actual: actual}
+}
+
+func Bytes(actual []byte) *BytesAssert {
+	return &BytesAssert{actual: actual}
+}
+
+func Reader(actual io.Reader) *ReaderAssert {
+	return &ReaderAssert{actual: actual}
+}
+
+func (assert *StringAssert) EqualTo(expected string, opts ...Option) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).EqualTo([]byte(expected), opts...)
+}
+
+func (assert *StringAssert) EqualToWithOptions(expected string, opts ...Option) hammy.AssertionMessage {
+	return assert.EqualTo(expected, opts...)
+}
+
+func (assert *ReaderAssert) EqualTo(expected io.Reader) hammy.AssertionMessage {
+	actualBytes, result := readYAML("actual", assert.actual)
 	if !result.IsSuccessful {
 		return result
 	}
@@ -33,15 +57,15 @@ func EqualReader(actual, expected io.Reader) hammy.AssertionMessage {
 		return result
 	}
 
-	return EqualBytes(actualBytes, expectedBytes)
+	return Bytes(actualBytes).EqualTo(expectedBytes)
 }
 
-func EqualBytes(actual, expected []byte) hammy.AssertionMessage {
-	return EqualBytesWithOptions(actual, expected)
+func (assert *BytesAssert) EqualTo(expected []byte, opts ...Option) hammy.AssertionMessage {
+	return assert.EqualToWithOptions(expected, opts...)
 }
 
-func EqualBytesWithOptions(actual, expected []byte, opts ...Option) hammy.AssertionMessage {
-	actualYAML, err := parseYAML(actual)
+func (assert *BytesAssert) EqualToWithOptions(expected []byte, opts ...Option) hammy.AssertionMessage {
+	actualYAML, err := parseYAML(assert.actual)
 	if err != nil {
 		return hammy.Assert(false, "actual YAML invalid: %v", err)
 	}
@@ -79,31 +103,31 @@ type compareOptions struct {
 	unorderedArrayPaths []string
 }
 
-func Valid(actual string) hammy.AssertionMessage {
-	return ValidBytes([]byte(actual))
+func (assert *StringAssert) IsValid() hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).IsValid()
 }
 
-func ValidReader(actual io.Reader) hammy.AssertionMessage {
-	actualBytes, result := readYAML("actual", actual)
+func (assert *ReaderAssert) IsValid() hammy.AssertionMessage {
+	actualBytes, result := readYAML("actual", assert.actual)
 	if !result.IsSuccessful {
 		return result
 	}
-	return ValidBytes(actualBytes)
+	return Bytes(actualBytes).IsValid()
 }
 
-func ValidBytes(actual []byte) hammy.AssertionMessage {
-	if _, err := parseYAMLDocuments(actual); err != nil {
+func (assert *BytesAssert) IsValid() hammy.AssertionMessage {
+	if _, err := parseYAMLDocuments(assert.actual); err != nil {
 		return hammy.Assert(false, "YAML invalid: %v", err)
 	}
 	return hammy.Assert(true, "got valid YAML")
 }
 
-func Contains(actual, expected string) hammy.AssertionMessage {
-	return ContainsBytes([]byte(actual), []byte(expected))
+func (assert *StringAssert) Contains(expected string) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).Contains([]byte(expected))
 }
 
-func ContainsBytes(actual, expected []byte) hammy.AssertionMessage {
-	actualYAML, err := parseYAML(actual)
+func (assert *BytesAssert) Contains(expected []byte) hammy.AssertionMessage {
+	actualYAML, err := parseYAML(assert.actual)
 	if err != nil {
 		return hammy.Assert(false, "actual YAML invalid: %v", err)
 	}
@@ -119,8 +143,12 @@ func ContainsBytes(actual, expected []byte) hammy.AssertionMessage {
 	return hammy.Assert(true, "YAML contained expected subset")
 }
 
-func PathExists(actual, path string) hammy.AssertionMessage {
-	actualYAML, err := parseYAML([]byte(actual))
+func (assert *StringAssert) PathExists(path string) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).PathExists(path)
+}
+
+func (assert *BytesAssert) PathExists(path string) hammy.AssertionMessage {
+	actualYAML, err := parseYAML(assert.actual)
 	if err != nil {
 		return hammy.Assert(false, "actual YAML invalid: %v", err)
 	}
@@ -133,8 +161,12 @@ func PathExists(actual, path string) hammy.AssertionMessage {
 	return hammy.Assert(true, "YAML path <%s> exists", path)
 }
 
-func PathMissing(actual, path string) hammy.AssertionMessage {
-	actualYAML, err := parseYAML([]byte(actual))
+func (assert *StringAssert) PathMissing(path string) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).PathMissing(path)
+}
+
+func (assert *BytesAssert) PathMissing(path string) hammy.AssertionMessage {
+	actualYAML, err := parseYAML(assert.actual)
 	if err != nil {
 		return hammy.Assert(false, "actual YAML invalid: %v", err)
 	}
@@ -147,12 +179,12 @@ func PathMissing(actual, path string) hammy.AssertionMessage {
 	return hammy.Assert(true, "YAML path <%s> missing", path)
 }
 
-func PathEqual(actual, path, expected string) hammy.AssertionMessage {
-	return PathEqualBytes([]byte(actual), path, []byte(expected))
+func (assert *StringAssert) PathEqual(path, expected string) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).PathEqual(path, []byte(expected))
 }
 
-func PathEqualBytes(actual []byte, path string, expected []byte) hammy.AssertionMessage {
-	actualYAML, err := parseYAML(actual)
+func (assert *BytesAssert) PathEqual(path string, expected []byte) hammy.AssertionMessage {
+	actualYAML, err := parseYAML(assert.actual)
 	if err != nil {
 		return hammy.Assert(false, "actual YAML invalid: %v", err)
 	}
@@ -174,12 +206,12 @@ func PathEqualBytes(actual []byte, path string, expected []byte) hammy.Assertion
 	return hammy.Assert(diff == "", "YAML path <%s> mismatch (-want +got):\n%s", path, diff)
 }
 
-func ArrayContains(actual, path, expectedElement string) hammy.AssertionMessage {
-	return ArrayContainsBytes([]byte(actual), path, []byte(expectedElement))
+func (assert *StringAssert) ArrayContains(path, expectedElement string) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).ArrayContains(path, []byte(expectedElement))
 }
 
-func ArrayContainsBytes(actual []byte, path string, expectedElement []byte) hammy.AssertionMessage {
-	actualYAML, err := parseYAML(actual)
+func (assert *BytesAssert) ArrayContains(path string, expectedElement []byte) hammy.AssertionMessage {
+	actualYAML, err := parseYAML(assert.actual)
 	if err != nil {
 		return hammy.Assert(false, "actual YAML invalid: %v", err)
 	}
@@ -209,24 +241,24 @@ func ArrayContainsBytes(actual []byte, path string, expectedElement []byte) hamm
 	return hammy.Assert(false, "got no matching element at YAML path <%s>", path)
 }
 
-func DocumentCount(actual string, expected int) hammy.AssertionMessage {
-	return DocumentCountBytes([]byte(actual), expected)
+func (assert *StringAssert) DocumentCount(expected int) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).DocumentCount(expected)
 }
 
-func DocumentCountBytes(actual []byte, expected int) hammy.AssertionMessage {
-	documents, err := parseYAMLDocuments(actual)
+func (assert *BytesAssert) DocumentCount(expected int) hammy.AssertionMessage {
+	documents, err := parseYAMLDocuments(assert.actual)
 	if err != nil {
 		return hammy.Assert(false, "YAML invalid: %v", err)
 	}
 	return hammy.Assert(len(documents) == expected, "got YAML document count <%d>, wanted <%d>", len(documents), expected)
 }
 
-func DocumentEqual(actual string, index int, expected string, opts ...Option) hammy.AssertionMessage {
-	return DocumentEqualBytes([]byte(actual), index, []byte(expected), opts...)
+func (assert *StringAssert) DocumentEqual(index int, expected string, opts ...Option) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).DocumentEqual(index, []byte(expected), opts...)
 }
 
-func DocumentEqualBytes(actual []byte, index int, expected []byte, opts ...Option) hammy.AssertionMessage {
-	documents, err := parseYAMLDocuments(actual)
+func (assert *BytesAssert) DocumentEqual(index int, expected []byte, opts ...Option) hammy.AssertionMessage {
+	documents, err := parseYAMLDocuments(assert.actual)
 	if err != nil {
 		return hammy.Assert(false, "actual YAML invalid: %v", err)
 	}
@@ -248,12 +280,12 @@ func DocumentEqualBytes(actual []byte, index int, expected []byte, opts ...Optio
 	return hammy.Assert(diff == "", "YAML document <%d> mismatch (-want +got):\n%s", index, diff)
 }
 
-func DocumentContains(actual string, index int, expected string) hammy.AssertionMessage {
-	return DocumentContainsBytes([]byte(actual), index, []byte(expected))
+func (assert *StringAssert) DocumentContains(index int, expected string) hammy.AssertionMessage {
+	return Bytes([]byte(assert.actual)).DocumentContains(index, []byte(expected))
 }
 
-func DocumentContainsBytes(actual []byte, index int, expected []byte) hammy.AssertionMessage {
-	documents, err := parseYAMLDocuments(actual)
+func (assert *BytesAssert) DocumentContains(index int, expected []byte) hammy.AssertionMessage {
+	documents, err := parseYAMLDocuments(assert.actual)
 	if err != nil {
 		return hammy.Assert(false, "actual YAML invalid: %v", err)
 	}

--- a/hammy/yamlassert/yamlassert_test.go
+++ b/hammy/yamlassert/yamlassert_test.go
@@ -14,17 +14,17 @@ import (
 func Test_Equal_success_reordered_mapping_keys(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.Equal("name: Ada\nage: 37\n", "age: 37.0\nname: Ada\n"))
+	assert.Is(yamlassert.String("name: Ada\nage: 37\n").EqualTo("age: 37.0\nname: Ada\n"))
 }
 
 func Test_Equal_success_anchor_alias(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.Equal("name: &name Ada\nuser:\n  name: *name\n", "name: Ada\nuser:\n  name: Ada\n"))
+	assert.Is(yamlassert.String("name: &name Ada\nuser:\n  name: *name\n").EqualTo("name: Ada\nuser:\n  name: Ada\n"))
 }
 
 func Test_Equal_failure_array_order_mismatch(t *testing.T) {
-	result := yamlassert.Equal("values: [1, 2, 3]\n", "values: [3, 2, 1]\n")
+	result := yamlassert.String("values: [1, 2, 3]\n").EqualTo("values: [3, 2, 1]\n")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -33,7 +33,7 @@ func Test_Equal_failure_array_order_mismatch(t *testing.T) {
 }
 
 func Test_Equal_failure_multiple_documents(t *testing.T) {
-	result := yamlassert.Equal("---\nname: Ada\n---\nname: Grace\n", "name: Ada\n")
+	result := yamlassert.String("---\nname: Ada\n---\nname: Grace\n").EqualTo("name: Ada\n")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -44,23 +44,23 @@ func Test_Equal_failure_multiple_documents(t *testing.T) {
 func Test_EqualBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.EqualBytes([]byte("one: 1\n"), []byte("one: 1.0\n")))
+	assert.Is(yamlassert.Bytes([]byte("one: 1\n")).EqualTo([]byte("one: 1.0\n")))
 }
 
 func Test_EqualReader_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.EqualReader(strings.NewReader("one: 1\n"), strings.NewReader("one: 1.0\n")))
+	assert.Is(yamlassert.Reader(strings.NewReader("one: 1\n")).EqualTo(strings.NewReader("one: 1.0\n")))
 }
 
 func Test_Valid_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.Valid("name: Ada\n"))
+	assert.Is(yamlassert.String("name: Ada\n").IsValid())
 }
 
 func Test_Valid_failure_invalid_yaml(t *testing.T) {
-	result := yamlassert.Valid("name: [Ada\n")
+	result := yamlassert.String("name: [Ada\n").IsValid()
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -69,7 +69,7 @@ func Test_Valid_failure_invalid_yaml(t *testing.T) {
 }
 
 func Test_Valid_failure_duplicate_key(t *testing.T) {
-	result := yamlassert.Valid("name: Ada\nname: Grace\n")
+	result := yamlassert.String("name: Ada\nname: Grace\n").IsValid()
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -80,17 +80,17 @@ func Test_Valid_failure_duplicate_key(t *testing.T) {
 func Test_ValidBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.ValidBytes([]byte("name: Ada\n")))
+	assert.Is(yamlassert.Bytes([]byte("name: Ada\n")).IsValid())
 }
 
 func Test_ValidReader_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.ValidReader(strings.NewReader("name: Ada\n")))
+	assert.Is(yamlassert.Reader(strings.NewReader("name: Ada\n")).IsValid())
 }
 
 func Test_ValidReader_failure_read_error(t *testing.T) {
-	result := yamlassert.ValidReader(errorReader{})
+	result := yamlassert.Reader(errorReader{}).IsValid()
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -101,11 +101,11 @@ func Test_ValidReader_failure_read_error(t *testing.T) {
 func Test_Contains_success_mapping_subset(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.Contains("status: ok\nmeta:\n  page: 1\n  request_id: abc\n", "meta:\n  page: 1.0\n"))
+	assert.Is(yamlassert.String("status: ok\nmeta:\n  page: 1\n  request_id: abc\n").Contains("meta:\n  page: 1.0\n"))
 }
 
 func Test_Contains_failure_missing_field(t *testing.T) {
-	result := yamlassert.Contains("status: ok\n", "meta:\n  page: 1\n")
+	result := yamlassert.String("status: ok\n").Contains("meta:\n  page: 1\n")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -116,23 +116,23 @@ func Test_Contains_failure_missing_field(t *testing.T) {
 func Test_ContainsBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.ContainsBytes([]byte("status: ok\nextra: true\n"), []byte("status: ok\n")))
+	assert.Is(yamlassert.Bytes([]byte("status: ok\nextra: true\n")).Contains([]byte("status: ok\n")))
 }
 
 func Test_PathExists_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.PathExists("user:\n  name: Ada\n", "user.name"))
+	assert.Is(yamlassert.String("user:\n  name: Ada\n").PathExists("user.name"))
 }
 
 func Test_PathExists_success_array_index(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.PathExists("items:\n  - id: 1\n", "items[0].id"))
+	assert.Is(yamlassert.String("items:\n  - id: 1\n").PathExists("items[0].id"))
 }
 
 func Test_PathExists_failure_missing(t *testing.T) {
-	result := yamlassert.PathExists("user:\n  name: Ada\n", "user.email")
+	result := yamlassert.String("user:\n  name: Ada\n").PathExists("user.email")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -143,11 +143,11 @@ func Test_PathExists_failure_missing(t *testing.T) {
 func Test_PathMissing_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.PathMissing("user:\n  name: Ada\n", "user.email"))
+	assert.Is(yamlassert.String("user:\n  name: Ada\n").PathMissing("user.email"))
 }
 
 func Test_PathMissing_failure_exists(t *testing.T) {
-	result := yamlassert.PathMissing("user:\n  name: Ada\n", "user.name")
+	result := yamlassert.String("user:\n  name: Ada\n").PathMissing("user.name")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -158,11 +158,11 @@ func Test_PathMissing_failure_exists(t *testing.T) {
 func Test_PathEqual_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.PathEqual("user:\n  age: 37\n", "user.age", "37.0\n"))
+	assert.Is(yamlassert.String("user:\n  age: 37\n").PathEqual("user.age", "37.0\n"))
 }
 
 func Test_PathEqual_failure_mismatch(t *testing.T) {
-	result := yamlassert.PathEqual("user:\n  name: Ada\n", "user.name", "Grace\n")
+	result := yamlassert.String("user:\n  name: Ada\n").PathEqual("user.name", "Grace\n")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -175,17 +175,17 @@ func Test_PathEqual_failure_mismatch(t *testing.T) {
 func Test_PathEqualBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.PathEqualBytes([]byte("user:\n  name: Ada\n"), "user.name", []byte("Ada\n")))
+	assert.Is(yamlassert.Bytes([]byte("user:\n  name: Ada\n")).PathEqual("user.name", []byte("Ada\n")))
 }
 
 func Test_ArrayContains_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.ArrayContains("items:\n  - id: 1\n  - id: 2\n", "items", "id: 2.0\n"))
+	assert.Is(yamlassert.String("items:\n  - id: 1\n  - id: 2\n").ArrayContains("items", "id: 2.0\n"))
 }
 
 func Test_ArrayContains_failure_missing_element(t *testing.T) {
-	result := yamlassert.ArrayContains("items:\n  - id: 1\n", "items", "id: 2\n")
+	result := yamlassert.String("items:\n  - id: 1\n").ArrayContains("items", "id: 2\n")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -196,14 +196,13 @@ func Test_ArrayContains_failure_missing_element(t *testing.T) {
 func Test_ArrayContainsBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.ArrayContainsBytes([]byte("items: [1, 2]\n"), "items", []byte("2.0\n")))
+	assert.Is(yamlassert.Bytes([]byte("items: [1, 2]\n")).ArrayContains("items", []byte("2.0\n")))
 }
 
 func Test_EqualWithOptions_success_ignore_paths(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.EqualWithOptions(
-		"status: ok\nmeta:\n  request_id: abc\n",
+	assert.Is(yamlassert.String("status: ok\nmeta:\n  request_id: abc\n").EqualTo(
 		"status: ok\nmeta:\n  request_id: xyz\n",
 		yamlassert.IgnorePaths("meta.request_id"),
 	))
@@ -212,8 +211,7 @@ func Test_EqualWithOptions_success_ignore_paths(t *testing.T) {
 func Test_EqualWithOptions_success_unordered_array(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.EqualWithOptions(
-		"tags: [go, test, yaml]\n",
+	assert.Is(yamlassert.String("tags: [go, test, yaml]\n").EqualTo(
 		"tags: [yaml, go, test]\n",
 		yamlassert.UnorderedArraysAt("tags"),
 	))
@@ -222,8 +220,7 @@ func Test_EqualWithOptions_success_unordered_array(t *testing.T) {
 func Test_EqualBytesWithOptions_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.EqualBytesWithOptions(
-		[]byte("tags: [go, test]\n"),
+	assert.Is(yamlassert.Bytes([]byte("tags: [go, test]\n")).EqualTo(
 		[]byte("tags: [test, go]\n"),
 		yamlassert.UnorderedArraysAt("tags"),
 	))
@@ -232,11 +229,11 @@ func Test_EqualBytesWithOptions_success(t *testing.T) {
 func Test_DocumentCount_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.DocumentCount("---\nname: Ada\n---\nname: Grace\n", 2))
+	assert.Is(yamlassert.String("---\nname: Ada\n---\nname: Grace\n").DocumentCount(2))
 }
 
 func Test_DocumentCount_failure(t *testing.T) {
-	result := yamlassert.DocumentCount("---\nname: Ada\n---\nname: Grace\n", 1)
+	result := yamlassert.String("---\nname: Ada\n---\nname: Grace\n").DocumentCount(1)
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -247,20 +244,19 @@ func Test_DocumentCount_failure(t *testing.T) {
 func Test_DocumentCountBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.DocumentCountBytes([]byte("---\nname: Ada\n---\nname: Grace\n"), 2))
+	assert.Is(yamlassert.Bytes([]byte("---\nname: Ada\n---\nname: Grace\n")).DocumentCount(2))
 }
 
 func Test_DocumentEqual_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.DocumentEqual("---\nname: Ada\n---\nname: Grace\n", 1, "name: Grace\n"))
+	assert.Is(yamlassert.String("---\nname: Ada\n---\nname: Grace\n").DocumentEqual(1, "name: Grace\n"))
 }
 
 func Test_DocumentEqual_success_with_options(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.DocumentEqual(
-		"---\nstatus: ok\nmeta:\n  request_id: abc\n",
+	assert.Is(yamlassert.String("---\nstatus: ok\nmeta:\n  request_id: abc\n").DocumentEqual(
 		0,
 		"status: ok\nmeta:\n  request_id: xyz\n",
 		yamlassert.IgnorePaths("meta.request_id"),
@@ -268,7 +264,7 @@ func Test_DocumentEqual_success_with_options(t *testing.T) {
 }
 
 func Test_DocumentEqual_failure_index_out_of_range(t *testing.T) {
-	result := yamlassert.DocumentEqual("---\nname: Ada\n", 1, "name: Ada\n")
+	result := yamlassert.String("---\nname: Ada\n").DocumentEqual(1, "name: Ada\n")
 
 	aSpy := eye.Spy()
 	assert := hammy.New(aSpy)
@@ -279,19 +275,19 @@ func Test_DocumentEqual_failure_index_out_of_range(t *testing.T) {
 func Test_DocumentEqualBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.DocumentEqualBytes([]byte("---\nname: Ada\n"), 0, []byte("name: Ada\n")))
+	assert.Is(yamlassert.Bytes([]byte("---\nname: Ada\n")).DocumentEqual(0, []byte("name: Ada\n")))
 }
 
 func Test_DocumentContains_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.DocumentContains("---\nstatus: ok\nmeta:\n  page: 1\n", 0, "meta:\n  page: 1.0\n"))
+	assert.Is(yamlassert.String("---\nstatus: ok\nmeta:\n  page: 1\n").DocumentContains(0, "meta:\n  page: 1.0\n"))
 }
 
 func Test_DocumentContainsBytes_success(t *testing.T) {
 	assert := hammy.New(t)
 
-	assert.Is(yamlassert.DocumentContainsBytes([]byte("---\nstatus: ok\n"), 0, []byte("status: ok\n")))
+	assert.Is(yamlassert.Bytes([]byte("---\nstatus: ok\n")).DocumentContains(0, []byte("status: ok\n")))
 }
 
 type errorReader struct{}


### PR DESCRIPTION
### Motivation

- Simplify and unify the YAML assertion API by providing typed assertion builders for string, byte slice, and reader inputs to enable fluent method calls.
- Make the YAML assertions more explicit and discoverable via `String`, `Bytes`, and `Reader` entry points instead of many top-level functions.

### Description

- Introduced `StringAssert`, `BytesAssert`, and `ReaderAssert` types and constructors `String()`, `Bytes()`, and `Reader()` and converted top-level functions into methods such as `EqualTo`, `EqualToWithOptions`, `IsValid`, `Contains`, `PathExists`, `PathMissing`, `PathEqual`, `ArrayContains`, `DocumentCount`, `DocumentEqual`, and `DocumentContains` on those types.
- Reworked `EqualReader`/`EqualBytes`/`Equal` flows to use the new fluent API internally and preserved option handling via `Option` (e.g. `IgnorePaths` and `UnorderedArraysAt`).
- Updated `hammy/README.md`, the `hammy/yamlassert` examples (`example_test.go`), and unit tests (`yamlassert_test.go`) to use the new API names and method calls, and updated the feature checklist to reflect the nested `String`/`Bytes`/`Reader` assertions.

### Testing

- Ran unit tests for the package using `go test ./...` and updated tests in `hammy/yamlassert` to use the new API, and all tests passed.
- Updated example tests in `hammy/yamlassert/example_test.go` to assert behavior via the new builders and verified their output in test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3938cdbbe4832d9179dd0dd4409c38)